### PR TITLE
feat: include another command to generate promotion message.

### DIFF
--- a/controller/bot.go
+++ b/controller/bot.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -83,6 +84,19 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message) {
 	log.Printf("[%s] %s", message.From.UserName, message.Text)
 
 	switch message.Command() {
+	case "getButton":
+		Announcement := strings.Split(message.Text, "  ")
+		if len(Announcement) > 1 {
+			parts := strings.Split(Announcement[2], " ")
+			if len(parts) > 2 {
+				url := parts[0]
+
+				// Extract the message (everything after the URL)
+				messageText := strings.Join(parts[1:], " ")
+				button := tgbotapi.NewInlineKeyboardButtonURL(messageText, url)
+				view.SendMessageWithKeyboardButton(bot, message.Chat.ID, Announcement[1], button)
+			}
+		}
 	case "start":
 		// Send a welcome message with instructions to start the game.
 		view.SendMessage(bot, message.Chat.ID, "Welcome! Use /word to start a game.")

--- a/controller/categoryBot/categoryBot.go
+++ b/controller/categoryBot/categoryBot.go
@@ -3,6 +3,7 @@ package categorybot
 import (
 	"fmt"
 	"log"
+	"strings"
 	"sync"
 	"time"
 
@@ -85,6 +86,19 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message) {
 	case "start":
 		// Send a welcome message with instructions to start the game.
 		view.SendMessage(bot, message.Chat.ID, "Welcome! Use /word to start a game.")
+	case "getButton":
+		Announcement := strings.Split(message.Text, "  ")
+		if len(Announcement) > 1 {
+			parts := strings.Split(Announcement[2], " ")
+			if len(parts) > 2 {
+				url := parts[0]
+
+				// Extract the message (everything after the URL)
+				messageText := strings.Join(parts[1:], " ")
+				button := tgbotapi.NewInlineKeyboardButtonURL(messageText, url)
+				view.SendMessageWithKeyboardButton(bot, message.Chat.ID, Announcement[1], button)
+			}
+		}
 	case "stats":
 		// Send the user stats of game.
 		result := service.LeaderBoardList("CrocEn")

--- a/view/response.go
+++ b/view/response.go
@@ -22,6 +22,20 @@ func SendMessageWithButtons(bot *tgbotapi.BotAPI, chatID int64, text string, but
 	return err
 }
 
+// SendMessageWithButtons sends a message with inline keyboard buttons to the user
+func SendMessageWithKeyboardButton(bot *tgbotapi.BotAPI, chatID int64, text string, buttons tgbotapi.InlineKeyboardButton) error {
+	// button := tgbotapi.NewInlineKeyboardButtonURL("Click Here", "url")
+	inlineKeyboard := tgbotapi.NewInlineKeyboardMarkup([]tgbotapi.InlineKeyboardButton{buttons})
+
+	// Create the message with the inline keyboard
+	msg := tgbotapi.NewMessage(chatID, text)
+	msg.ReplyMarkup = inlineKeyboard
+
+	// Send the message
+	_, err := bot.Send(msg)
+	return err
+}
+
 // SendSticker sends a sticker to the user
 func SendSticker(bot *tgbotapi.BotAPI, chatID int64, stickerFileID string) error {
 	sticker := tgbotapi.NewStickerShare(chatID, stickerFileID)


### PR DESCRIPTION
Add a /getButton command to flex promo messages with clickable buttons.

Yo! This update is here to make your bot game stronger:

New Command /getButton:

Splits the message to grab the promo title, URL, and text.
Drops a slick button with the link and message attached.
Sends it all in one clean move—no hassle, just vibes.
New Button Magic:

Added SendMessageWithKeyboardButton function for handling buttons like a pro.
Updated bot.go and categoryBot.go to vibe with the new command.
What’s in it for users?

More interactivity = more engagement = 💯.
Promo links, but make it cool.
Wrap Up: It’s quick, clean, and gets people clicking. 🚀