### PR TITLE
feat: leader wont receive a congrats message.

### DIFF
--- a/controller/bot.go
+++ b/controller/bot.go
@@ -154,7 +154,7 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message) {
 		chatState.RUnlock()
 
 		// Check if the guessed word matches the current word.
-		if user != 0 && service.NormalizeAndCompare(message.Text, word) {
+		if user != 0 && service.NormalizeAndCompare(message.Text, word) && message.From.ID != user {
 			buttons := tgbotapi.NewInlineKeyboardMarkup(
 				// First line with a single button
 				tgbotapi.NewInlineKeyboardRow(

--- a/controller/categoryBot/categoryBot.go
+++ b/controller/categoryBot/categoryBot.go
@@ -152,7 +152,7 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message) {
 		chatState.RUnlock()
 
 		// Check if the guessed word matches the current word.
-		if user != 0 && service.NormalizeAndCompare(message.Text, word) {
+		if user != 0 && service.NormalizeAndCompare(message.Text, word) && message.From.ID != user {
 			buttons := tgbotapi.NewInlineKeyboardMarkup(
 				// First line with a single button
 				tgbotapi.NewInlineKeyboardRow(


### PR DESCRIPTION
Alright, here’s the deal:  
We’re making it so the leader can actually use the word in the hint while explaining. No more holding back, just full-send the word and let the creativity flow.  

**What’s New?**  
- The service now chills and lets the leader include the actual word in their hints.  
- Better gameplay, more fun, and fewer restrictions—because why not?  

**Why tho?**  
- Makes the game smoother.  
- Keeps the vibes alive by letting leaders do their thing.  

That’s it. Simple but 🔥. 