### PR TITLE
Use `html` for Leaderboard Command Output

### DIFF
--- a/controller/bot.go
+++ b/controller/bot.go
@@ -256,7 +256,7 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message) {
 
 		if message.Command() == "leaderstats" {
 			result := service.LeaderBoardList("CrocEnLeader")
-			view.SendMessage(bot, chatID, result)
+			view.SendMessagehtml(bot, chatID, result)
 		}
 		chatState.RLock()
 		wordEmpty := chatState.Word == ""


### PR DESCRIPTION
**Summary:**
This MR updates the message sending function for the `/leaderstats` command. Instead of using `SendMessage`, which sends plain text, it now uses `SendMessagehtml` to support HTML formatting in the leaderboard response.

**Changes Made:**

* Replaced `view.SendMessage(bot, chatID, result)` with `view.SendMessagehtml(bot, chatID, result)` in the `/leaderstats` command handler.

**Reason for Change:**

* To enhance the formatting of leaderboard messages by allowing HTML styling for better readability and user experience in Telegram.

**Impact:**

* Improved message presentation for users executing the `/leaderstats` command.

