### PR TITLE
Add User Stats Retrieval for Guesses and Leadership

### DIFF
--- a/service/leaderBoardList.go
+++ b/service/leaderBoardList.go
@@ -63,11 +63,22 @@ func GetUserStatsByID(userID int) string {
 
 	result, err := repository.GetUserStatsByID(client, "CrocEn", userID)
 	if err != nil {
-		return fmt.Sprintf("No stats found for user ID %d", userID)
+		return "No stats found"
 	}
 
 	name, _ := result["Name"].(string)
 	count, _ := result["count"].(int32)
 
-	return fmt.Sprintf("You %s have successfully guessed for:\n%d Times", name, count)
+	stats := fmt.Sprintf("You %s have successfully guessed for:\n%d Times", name, count)
+	result, err = repository.GetUserStatsByID(client, "CrocEnLeader", userID)
+	if err != nil {
+		return stats + "\n:)"
+	}
+
+	// name, _ = result["Name"].(string)
+	count, _ = result["count"].(int32)
+
+	stats += fmt.Sprintf("\nAnd have leaded for:\n%d Times", count)
+	return stats
+
 }


### PR DESCRIPTION

### **Description**:

This MR enhances the user statistics retrieval functionality by:

* Querying the `GetUserStatsByID` function twice with different contexts:

  * `"CrocEn"` for tracking **guess counts**
  * `"CrocEnLeader"` for tracking **leadership counts**
* Providing a user-friendly summary of both stats.
* Returning a fallback message when either stat is unavailable.

### **Code Behavior**:

1. Retrieves user's guess count.
2. If guess data exists:

   * Extracts `Name` and `count`
   * Formats a message:
     `You <Name> have successfully guessed for: <count> Times`
3. Then attempts to retrieve leadership count.
4. If found:

   * Appends:
     `And have leaded for: <count> Times`
5. If leadership data is missing:

   * Adds a friendly face `":)"` to the output.

### **Sample Output**:

```
You Alice have successfully guessed for:
5 Times
And have leaded for:
3 Times
```

Or in case leadership data is missing:

```
You Alice have successfully guessed for:
5 Times
:)
```

