### PR TITLE
Add Support for Sending Log Files and Refactor File Sending Logic

### DIFF
--- a/controller/bot.go
+++ b/controller/bot.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -282,6 +283,24 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 			msgstr, _ := MessageToJSONString(message)
 			view.SendMessage(bot, adminID, msgstr)
 			view.SendMessage(bot, chatID, "Thank you! Your report has been successfully submitted.")
+		case "getlogs":
+			logFilePath := "output.log"
+			data, err := os.ReadFile(logFilePath)
+			if err != nil {
+				view.SendMessage(bot, chatID, fmt.Sprintf("Failed to read log file: %v", err))
+				return
+			}
+			file := tgbotapi.FileBytes{
+				Name:  "output.log",
+				Bytes: data,
+			}
+			msg := tgbotapi.NewDocumentUpload(adminID, file)
+			_, err = bot.Send(msg)
+			if err != nil {
+				view.SendMessage(bot, chatID, fmt.Sprintf("Failed to send log file: %v", err))
+				return
+			}
+			view.SendMessage(bot, chatID, "Log file sent to admin successfully.")
 		}
 
 		aiModeMutex.Lock()

--- a/controller/bot.go
+++ b/controller/bot.go
@@ -219,12 +219,7 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 				if err != nil {
 					return fmt.Errorf("failed to export %s data: %w", name, err)
 				}
-				file := tgbotapi.FileBytes{
-					Name:  filename,
-					Bytes: data,
-				}
-				msg := tgbotapi.NewDocumentUpload(adminID, file)
-				_, err = bot.Send(msg)
+				err = view.SendFile(bot, adminID, filename, data)
 				if err != nil {
 					return fmt.Errorf("failed to send %s data file: %w", name, err)
 				}
@@ -290,12 +285,7 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 				view.SendMessage(bot, chatID, fmt.Sprintf("Failed to read log file: %v", err))
 				return
 			}
-			file := tgbotapi.FileBytes{
-				Name:  "output.log",
-				Bytes: data,
-			}
-			msg := tgbotapi.NewDocumentUpload(adminID, file)
-			_, err = bot.Send(msg)
+			err = view.SendFile(bot, adminID, "output.log", data)
 			if err != nil {
 				view.SendMessage(bot, chatID, fmt.Sprintf("Failed to send log file: %v", err))
 				return

--- a/view/response.go
+++ b/view/response.go
@@ -101,3 +101,14 @@ func ReactToMessage(botToken string, chatID int64, messageID int, emoji string, 
 
 	return nil
 }
+
+// SendFile sends a file/document to the user
+func SendFile(bot *tgbotapi.BotAPI, chatID int64, filename string, data []byte) error {
+	file := tgbotapi.FileBytes{
+		Name:  filename,
+		Bytes: data,
+	}
+	msg := tgbotapi.NewDocumentUpload(chatID, file)
+	_, err := bot.Send(msg)
+	return err
+}


### PR DESCRIPTION
This PR introduces a new `/getlogs` command that allows users to request and send the application log file (`output.log`) to the admin. It also refactors the existing logic for sending files to centralize file transfer operations via a new helper function.

---

### **Changes Made:**

* **Feature:**

  * Added support for a new bot command: `/getlogs`

    * Reads the `output.log` file.
    * Sends it to the admin using the centralized `SendFile` function.
    * Informs the user whether the operation was successful or not.

* **Refactor:**

  * Moved document sending logic into a reusable helper function `SendFile` inside `view/response.go`.

* **Improvements:**

  * Reduced code duplication when sending documents through Telegram.
  * Improved maintainability and readability of file upload logic.

---

### **Files Modified:**

* `controller/bot.go`
* `view/response.go`

---

