### PR TITLE
Make /stats and /leaderstats group-specific, add global commands

### DIFF
--- a/controller/bot.go
+++ b/controller/bot.go
@@ -258,8 +258,15 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 			view.SendMessage(bot, chatID, "Both datasets exported and sent to admin successfully.")
 			return
 		case "stats":
-			result := service.LeaderBoardList(client, "CrocEn")
+			view.SendMessage(bot, chatID, "Group stats are not available in a DM. You can view global stats using /statsglobal or /leaderstatsglobal.")
+		case "leaderstats":
+			view.SendMessage(bot, chatID, "Group stats are not available in a DM. You can view global stats using /statsglobal or /leaderstatsglobal.")
+		case "statsglobal":
+			result := service.LeaderBoardList(client, "CrocEn", 0)
 			view.SendMessagehtml(bot, chatID, result)
+		case "leaderstatsglobal":
+			result := service.LeaderBoardList(client, "CrocEnLeader", 0)
+			view.SendMessagehtml(bot, message.Chat.ID, result)
 		case "mystats":
 			// args := strings.Fields(message.CommandArguments())
 			// if len(args) < 1 {
@@ -276,9 +283,6 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 			}
 			result := service.GetUserStatsByID(client, userID)
 			view.ReplyToMessage(bot, message.MessageID, chatID, result)
-		case "leaderstats":
-			result := service.LeaderBoardList(client, "CrocEnLeader")
-			view.SendMessagehtml(bot, message.Chat.ID, result)
 		case "installAI":
 			logs, err := installOllama.Install(true)
 			logsText := strings.Join(logs, "\n")
@@ -478,14 +482,20 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 	case "start":
 		view.SendMessage(bot, message.Chat.ID, "Welcome! Type /word to start a new game.")
 	case "stats":
-		result := service.LeaderBoardList(client, "CrocEn")
+		result := service.LeaderBoardList(client, "CrocEn", message.Chat.ID)
+		view.SendMessagehtml(bot, message.Chat.ID, result)
+	case "leaderstats":
+		result := service.LeaderBoardList(client, "CrocEnLeader", message.Chat.ID)
+		view.SendMessagehtml(bot, message.Chat.ID, result)
+	case "statsglobal":
+		result := service.LeaderBoardList(client, "CrocEn", 0)
+		view.SendMessagehtml(bot, message.Chat.ID, result)
+	case "leaderstatsglobal":
+		result := service.LeaderBoardList(client, "CrocEnLeader", 0)
 		view.SendMessagehtml(bot, message.Chat.ID, result)
 	case "mystats":
 		result := service.GetUserStatsByID(client, message.From.ID)
 		view.ReplyToMessage(bot, message.MessageID, chatID, result)
-	case "leaderstats":
-		result := service.LeaderBoardList(client, "CrocEnLeader")
-		view.SendMessagehtml(bot, message.Chat.ID, result)
 	case "rules":
 		rulesText := "*🎮 Game Rules 🎮*\n\n" +
 			"*Players:*\n" +

--- a/controller/categoryBot/categoryBot.go
+++ b/controller/categoryBot/categoryBot.go
@@ -308,8 +308,15 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 			view.SendMessage(bot, chatID, "Both datasets exported and sent to admin successfully.")
 			return
 		case "stats":
-			result := service.LeaderBoardList(client, "CrocEn")
+			view.SendMessage(bot, chatID, "Group stats are not available in a DM. You can view global stats using /statsglobal or /leaderstatsglobal.")
+		case "leaderstats":
+			view.SendMessage(bot, chatID, "Group stats are not available in a DM. You can view global stats using /statsglobal or /leaderstatsglobal.")
+		case "statsglobal":
+			result := service.LeaderBoardList(client, "CrocEn", 0)
 			view.SendMessagehtml(bot, chatID, result)
+		case "leaderstatsglobal":
+			result := service.LeaderBoardList(client, "CrocEnLeader", 0)
+			view.SendMessagehtml(bot, message.Chat.ID, result)
 		case "mystats":
 			// args := strings.Fields(message.CommandArguments())
 			// if len(args) < 1 {
@@ -326,9 +333,6 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 			}
 			result := service.GetUserStatsByID(client, userID)
 			view.ReplyToMessage(bot, message.MessageID, chatID, result)
-		case "leaderstats":
-			result := service.LeaderBoardList(client, "CrocEnLeader")
-			view.SendMessagehtml(bot, message.Chat.ID, result)
 		case "installAI":
 			logs, err := installOllama.Install(true)
 			logsText := strings.Join(logs, "\n")
@@ -584,14 +588,20 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 	case "start":
 		view.SendMessage(bot, message.Chat.ID, "Welcome! Type /word to start a new game.")
 	case "stats":
-		result := service.LeaderBoardList(client, "CrocEn")
+		result := service.LeaderBoardList(client, "CrocEn", message.Chat.ID)
+		view.SendMessagehtml(bot, message.Chat.ID, result)
+	case "leaderstats":
+		result := service.LeaderBoardList(client, "CrocEnLeader", message.Chat.ID)
+		view.SendMessagehtml(bot, message.Chat.ID, result)
+	case "statsglobal":
+		result := service.LeaderBoardList(client, "CrocEn", 0)
+		view.SendMessagehtml(bot, message.Chat.ID, result)
+	case "leaderstatsglobal":
+		result := service.LeaderBoardList(client, "CrocEnLeader", 0)
 		view.SendMessagehtml(bot, message.Chat.ID, result)
 	case "mystats":
 		result := service.GetUserStatsByID(client, message.From.ID)
 		view.ReplyToMessage(bot, message.MessageID, chatID, result)
-	case "leaderstats":
-		result := service.LeaderBoardList(client, "CrocEnLeader")
-		view.SendMessagehtml(bot, message.Chat.ID, result)
 	case "rules":
 		rulesText := "*🎮 Game Rules 🎮*\n\n" +
 			"*Players:*\n" +

--- a/repository/dbManager.go
+++ b/repository/dbManager.go
@@ -98,22 +98,29 @@ func ReadAllDoc(client *mongo.Client, collection string) []bson.M {
 }
 
 // Function to count occurrences of each ID along with the Name
-func CountIDOccurrences(client *mongo.Client, collection string) ([]map[string]interface{}, error) {
+func CountIDOccurrences(client *mongo.Client, collection string, chatID int64) ([]map[string]interface{}, error) {
 	database := client.Database("Telegram")
 	commentCollection := database.Collection(collection)
 
 	// Aggregation pipeline to count occurrences of each ID and include the Name
-	pipeline := mongo.Pipeline{
+	var pipeline mongo.Pipeline
+
+	// If chatID is provided (non-zero), filter by chat_ID
+	if chatID != 0 {
+		pipeline = append(pipeline, bson.D{{"$match", bson.D{{Key: "chat_ID", Value: chatID}}}})
+	}
+
+	pipeline = append(pipeline,
 		// Group by ID, count occurrences, and include Name
-		{{"$group", bson.D{
+		bson.D{{"$group", bson.D{
 			{Key: "_id", Value: "$ID"},                                    // Group by the "ID" field
 			{Key: "count", Value: bson.D{{Key: "$sum", Value: 1}}},        // Count occurrences
 			{Key: "Name", Value: bson.D{{Key: "$first", Value: "$Name"}}}, // Get the first "Name" encountered for the grouped ID
 		}}},
 
 		// Sort by count (descending)
-		{{"$sort", bson.D{{Key: "count", Value: -1}}}},
-	}
+		bson.D{{"$sort", bson.D{{Key: "count", Value: -1}}}},
+	)
 
 	// Execute the aggregation query
 	cursor, err := commentCollection.Aggregate(context.TODO(), pipeline)

--- a/service/leaderBoardList.go
+++ b/service/leaderBoardList.go
@@ -9,8 +9,8 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
-func LeaderBoardList(client *mongo.Client, collection string) string {
-	idCounts, err := repository.CountIDOccurrences(client, collection)
+func LeaderBoardList(client *mongo.Client, collection string, chatID int64) string {
+	idCounts, err := repository.CountIDOccurrences(client, collection, chatID)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This pull request updates the `/stats` and `/leaderstats` commands to be group-specific, displaying stats only for the current chat. It also introduces `/statsglobal` and `/leaderstatsglobal` to retrieve the global leaderboards. If `/stats` or `/leaderstats` is used in a Direct Message, the bot now responds with a message indicating that group stats are not available in a DM, and suggests the global commands.

The changes involve updating the MongoDB aggregation pipeline in `repository/dbManager.go` to optionally filter by `chat_ID`, passing this down from the controller layer.

---
*PR created automatically by Jules for task [13139529271124880879](https://jules.google.com/task/13139529271124880879) started by @MUSTAFA-A-KHAN*