### PR TITLE
⚡ Bolt: Use Singleton MongoDB Client to Reuse Connection Pool

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-30 - [Performance Optimization for SCRAMY Dictionary Search]
 **Learning:** Checking word validity inside a nested loop when generating scrambled letters was creating an O(N*M) bottleneck during game generation, which scaled linearly with the number of valid words and generation iterations.
 **Action:** Replaced the character-by-character scan and array list checking by preprocessing the word lists into `validWordsMap` and pre-constructing a character set mapping. This reduces validity checking during generation to faster hash lookups.
+## 2024-06-01 - Singleton MongoDB Client
+**Learning:** The MongoDB Go driver establishes a connection pool. Creating a new `mongo.Client` on every request or in multiple places drains resources, degrades performance, and can lead to connection exhaustion, especially on cloud clusters.
+**Action:** Always implement a singleton pattern (e.g., using `sync.Once`) for the database client so the connection pool is reused across the entire application.

--- a/repository/dbManager.go
+++ b/repository/dbManager.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/url"
+	"sync"
 
 	"time"
 
@@ -14,7 +15,19 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
+var (
+	clientInstance *mongo.Client
+	clientMutex    sync.Mutex
+)
+
 func DbManager() *mongo.Client {
+	clientMutex.Lock()
+	defer clientMutex.Unlock()
+
+	if clientInstance != nil {
+		return clientInstance
+	}
+
 	fmt.Print("into DBmanager")
 	passsword := "pass@123"
 	encodedPassword := url.QueryEscape(passsword)
@@ -24,6 +37,7 @@ func DbManager() *mongo.Client {
 	client, err := mongo.Connect(context.TODO(), clientOptions)
 	if err != nil {
 		log.Print(err)
+		return nil
 	}
 
 	// Ensure connection is established
@@ -32,7 +46,9 @@ func DbManager() *mongo.Client {
 		return nil
 	}
 	fmt.Println("Connected to MongoDB successfully!")
-	return client
+	clientInstance = client
+
+	return clientInstance
 }
 func InsertDoc(ID int, Name string, chatID int64, client *mongo.Client, collection string) {
 	defer func() {


### PR DESCRIPTION
⚡ Bolt: Implemented a singleton pattern for the MongoDB client in `repository/DbManager`.

💡 What: Changed the `DbManager()` function to store and return a single, globally shared instance of `*mongo.Client` instead of establishing a new connection to the database on every invocation.
🎯 Why: Previously, `DbManager()` was creating a brand new MongoDB client, parsing the URI, and establishing a new network connection pool every single time it was called (which happens frequently, e.g., on every `/getinfo` command). This leads to severe performance degradation, high latency, and rapid connection exhaustion on the MongoDB server.
📊 Impact: Expected to dramatically reduce database latency by reusing the underlying connection pool. Eliminates the risk of connection exhaustion and significantly lowers memory overhead.
🔬 Measurement: Run a load test against the bot (e.g., repeatedly calling an endpoint that uses the database) and observe the number of active connections in the MongoDB Atlas dashboard. The connections should now remain stable rather than spiking linearly.

---
*PR created automatically by Jules for task [11480936598507121159](https://jules.google.com/task/11480936598507121159) started by @MUSTAFA-A-KHAN*