### PR TITLE
fix: Ignore non-alphabetical Wordle guesses

### DIFF
--- a/controller/translator/eordle.go
+++ b/controller/translator/eordle.go
@@ -44,7 +44,7 @@ func (t *TextTranslator) SolveWordle(puzzle string) string {
 	candidates, err := findCandidates(pattern, present, excluded, notIn)
 	if err == nil && len(candidates) > 0 {
 		best := chooseBestCandidate(candidates)
-		return fmt.Sprintf("Best next word: %s\n\n<i>Beware: Every Eordle costs 5 points.</i>", best)
+		return fmt.Sprintf("Best next word: %s\n\n<i>ᴮᵉʷᵃʳᵉ, ᵉᵛᵉʳʸ ᴱᵒʳᵈˡᵉ ᶜᵒˢᵗˢ ⁵ ᵖᵒⁱⁿᵗˢ.</i>", best)
 	}
 	if OpenAIKey == "" {
 		analysis := t.AnalyzeEordle(input)
@@ -114,7 +114,7 @@ func (t *TextTranslator) SolveWordle(puzzle string) string {
 		}
 
 		if validateCandidate(word, pattern, present, excluded, notIn) {
-			return fmt.Sprintf("Best next word: %s\n\n<i>Beware: Every Eordle costs 5 points.</i>", word)
+			return fmt.Sprintf("Best next word: %s\n\n<i>ᴮᵉʷᵃʳᵉ, ᵉᵛᵉʳʸ ᴱᵒʳᵈˡᵉ ᶜᵒˢᵗˢ ⁵ ᵖᵒⁱⁿᵗˢ.</i>", word)
 		}
 
 		// If invalid, append a clarification and retry

--- a/controller/wordlebot/wordlebot.go
+++ b/controller/wordlebot/wordlebot.go
@@ -292,8 +292,17 @@ func HandleGuess(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mongo.
 	}
 
 	guess := strings.ToLower(strings.TrimSpace(text))
+
+	// Check if it's exactly 5 bytes (ASCII check)
 	if len(guess) != 5 {
 		return // Not a valid guess format, ignore
+	}
+
+	// Ensure all characters are valid English alphabet letters
+	for i := 0; i < len(guess); i++ {
+		if guess[i] < 'a' || guess[i] > 'z' {
+			return // Ignore non-alphabetical inputs completely
+		}
 	}
 
 	wordsMutex.RLock()


### PR DESCRIPTION
Update `HandleGuess` to ignore non-alphabetical Wordle guesses.

---
*PR created automatically by Jules for task [889764101274688572](https://jules.google.com/task/889764101274688572) started by @MUSTAFA-A-KHAN*