### PR TITLE
feat: add shop feature for custom emojis

### DIFF
--- a/controller/bot.go
+++ b/controller/bot.go
@@ -223,9 +223,13 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 			button := tgbotapi.NewInlineKeyboardButtonURL("add to group", "https://t.me/Croco_rebirth_bot?startgroup=true")
 			view.SendMessageWithKeyboardButton(bot, chatID, "Unlock my full potential by adding me to a group chat!", button)
 		case "start":
-			buttons := tgbotapi.NewInlineKeyboardMarkup(
-				tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Get Hint"+telegramReactions[20], "hint")))
-			view.SendMessageWithButtons(bot, message.Chat.ID, "Heyyy! Got a word for ya 😏 Tap the button below if you need a lil hint 👇", buttons)
+			if message.CommandArguments() == "shop" {
+				showShop(bot, message.Chat.ID)
+			} else {
+				buttons := tgbotapi.NewInlineKeyboardMarkup(
+					tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Get Hint"+telegramReactions[20], "hint")))
+				view.SendMessageWithButtons(bot, message.Chat.ID, "Heyyy! Got a word for ya 😏 Tap the button below if you need a lil hint 👇", buttons)
+			}
 		case "exportdata":
 			if message.From.ID != int(adminID) {
 				log.Printf("not an admin")

--- a/controller/bot.go
+++ b/controller/bot.go
@@ -267,6 +267,21 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 		case "leaderstatsglobal":
 			result := service.LeaderBoardList(client, "CrocEnLeader", 0)
 			view.SendMessagehtml(bot, message.Chat.ID, result)
+		case "shop":
+			if message.Chat.IsPrivate() {
+				// Handle shop in DM
+				showShop(bot, message.Chat.ID)
+			} else {
+				// Send a link to DM
+				botUsername := bot.Self.UserName
+				link := fmt.Sprintf("https://t.me/%s?start=shop", botUsername)
+				markup := tgbotapi.NewInlineKeyboardMarkup(
+					tgbotapi.NewInlineKeyboardRow(
+						tgbotapi.NewInlineKeyboardButtonURL("🛒 Go to Shop", link),
+					),
+				)
+				view.SendMessageWithButtons(bot, message.Chat.ID, "Click the button below to visit the Emoji Shop!", markup)
+			}
 		case "mystats":
 			buttons := tgbotapi.NewInlineKeyboardMarkup(
 				tgbotapi.NewInlineKeyboardRow(
@@ -503,13 +518,32 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 			}
 		}
 	case "start":
-		view.SendMessage(bot, message.Chat.ID, "Welcome! Type /word to start a new game.")
+		if message.CommandArguments() == "shop" {
+			showShop(bot, message.Chat.ID)
+		} else {
+			view.SendMessage(bot, message.Chat.ID, "Welcome! Type /word to start a new game.")
+		}
 	case "stats":
 		buttons := tgbotapi.NewInlineKeyboardMarkup(tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Word Guess Group", "statsgroup_wordguess"), tgbotapi.NewInlineKeyboardButtonData("Wordle Group", "statsgroup_wordle")))
 		view.SendMessageWithButtons(bot, chatID, "🐊🇮🇳\n📊 Choose group stats to view:", buttons)
 	case "leaderstats":
 		result := service.LeaderBoardList(client, "CrocEnLeader", message.Chat.ID)
 		view.SendMessagehtml(bot, message.Chat.ID, result)
+	case "shop":
+		if message.Chat.IsPrivate() {
+			// Handle shop in DM
+			showShop(bot, message.Chat.ID)
+		} else {
+			// Send a link to DM
+			botUsername := bot.Self.UserName
+			link := fmt.Sprintf("https://t.me/%s?start=shop", botUsername)
+			markup := tgbotapi.NewInlineKeyboardMarkup(
+				tgbotapi.NewInlineKeyboardRow(
+					tgbotapi.NewInlineKeyboardButtonURL("🛒 Go to Shop", link),
+				),
+			)
+			view.SendMessageWithButtons(bot, message.Chat.ID, "Click the button below to visit the Emoji Shop!", markup)
+		}
 	case "statsglobal":
 		buttons := tgbotapi.NewInlineKeyboardMarkup(tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Word Guess Global", "statsglobal_wordguess"), tgbotapi.NewInlineKeyboardButtonData("Wordle Global", "statsglobal_wordle")))
 		view.SendMessageWithButtons(bot, chatID, "🐊🇮🇳\n📊 Choose global stats to view:", buttons)
@@ -731,6 +765,10 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 
 // handleCallbackQuery processes incoming callback queries and handles the "explain" action.
 func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery, client *mongo.Client) {
+	if handleShopCallback(bot, callback, client) {
+		return
+	}
+
 	chatID := callback.Message.Chat.ID
 	chatState := getOrCreateChatState(chatID)
 

--- a/controller/categoryBot/categoryBot.go
+++ b/controller/categoryBot/categoryBot.go
@@ -281,9 +281,13 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 			button := tgbotapi.NewInlineKeyboardButtonURL("add to group", "https://t.me/Croco_rebirth_bot?startgroup=true")
 			view.SendMessageWithKeyboardButton(bot, chatID, "Unlock my full potential by adding me to a group chat!", button)
 		case "start":
-			buttons := tgbotapi.NewInlineKeyboardMarkup(
-				tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Get Hint"+telegramReactions[20], "hint")))
-			view.SendMessageWithButtons(bot, message.Chat.ID, "Heyyy! Got a word for ya 😏 Tap the button below if you need a lil hint 👇", buttons)
+			if message.CommandArguments() == "shop" {
+				showShop(bot, message.Chat.ID)
+			} else {
+				buttons := tgbotapi.NewInlineKeyboardMarkup(
+					tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Get Hint"+telegramReactions[20], "hint")))
+				view.SendMessageWithButtons(bot, message.Chat.ID, "Heyyy! Got a word for ya 😏 Tap the button below if you need a lil hint 👇", buttons)
+			}
 		case "wordle":
 			wordlebot.HandleWordleCommand(bot, chatID, message.From.FirstName)
 			return
@@ -635,7 +639,11 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 		view.SendMessage(bot, chatID, "AI mode is now enabled! Enjoy the smart responses.")
 		return
 	case "start":
-		view.SendMessage(bot, message.Chat.ID, "Welcome! Type /word to start a new game.")
+		if message.CommandArguments() == "shop" {
+			showShop(bot, message.Chat.ID)
+		} else {
+			view.SendMessage(bot, message.Chat.ID, "Welcome! Type /word to start a new game.")
+		}
 	case "wordle":
 		wordlebot.HandleWordleCommand(bot, chatID, message.From.FirstName)
 		return

--- a/controller/categoryBot/categoryBot.go
+++ b/controller/categoryBot/categoryBot.go
@@ -328,6 +328,21 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 		case "leaderstatsglobal":
 			result := service.LeaderBoardList(client, "CrocEnLeader", 0)
 			view.SendMessagehtml(bot, message.Chat.ID, result)
+		case "shop":
+			if message.Chat.IsPrivate() {
+				// Handle shop in DM
+				showShop(bot, message.Chat.ID)
+			} else {
+				// Send a link to DM
+				botUsername := bot.Self.UserName
+				link := fmt.Sprintf("https://t.me/%s?start=shop", botUsername)
+				markup := tgbotapi.NewInlineKeyboardMarkup(
+					tgbotapi.NewInlineKeyboardRow(
+						tgbotapi.NewInlineKeyboardButtonURL("🛒 Go to Shop", link),
+					),
+				)
+				view.SendMessageWithButtons(bot, message.Chat.ID, "Click the button below to visit the Emoji Shop!", markup)
+			}
 		case "mystats":
 			buttons := tgbotapi.NewInlineKeyboardMarkup(
 				tgbotapi.NewInlineKeyboardRow(
@@ -630,6 +645,21 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 	case "leaderstats":
 		result := service.LeaderBoardList(client, "CrocEnLeader", message.Chat.ID)
 		view.SendMessagehtml(bot, message.Chat.ID, result)
+	case "shop":
+		if message.Chat.IsPrivate() {
+			// Handle shop in DM
+			showShop(bot, message.Chat.ID)
+		} else {
+			// Send a link to DM
+			botUsername := bot.Self.UserName
+			link := fmt.Sprintf("https://t.me/%s?start=shop", botUsername)
+			markup := tgbotapi.NewInlineKeyboardMarkup(
+				tgbotapi.NewInlineKeyboardRow(
+					tgbotapi.NewInlineKeyboardButtonURL("🛒 Go to Shop", link),
+				),
+			)
+			view.SendMessageWithButtons(bot, message.Chat.ID, "Click the button below to visit the Emoji Shop!", markup)
+		}
 	case "statsglobal":
 		buttons := tgbotapi.NewInlineKeyboardMarkup(tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Word Guess Global", "statsglobal_wordguess"), tgbotapi.NewInlineKeyboardButtonData("Wordle Global", "statsglobal_wordle")))
 		view.SendMessageWithButtons(bot, chatID, "🐊🇮🇳\n📊 Choose global stats to view:", buttons)
@@ -917,6 +947,10 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 
 // handleCallbackQuery processes incoming callback queries and handles the "explain" action.
 func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery, client *mongo.Client) {
+	if handleShopCallback(bot, callback, client) {
+		return
+	}
+
 	chatID := callback.Message.Chat.ID
 	chatState := getOrCreateChatState(chatID)
 

--- a/controller/categoryBot/shopCallback.go
+++ b/controller/categoryBot/shopCallback.go
@@ -1,0 +1,138 @@
+package categorybot
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/repository"
+	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/service"
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+func handleShopCallback(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery, client *mongo.Client) bool {
+	data := callback.Data
+
+	if data == "inventory" {
+		showInventory(bot, callback, client)
+		return true
+	} else if strings.HasPrefix(data, "buy_emoji_") {
+		emoji := strings.TrimPrefix(data, "buy_emoji_")
+		handleBuyEmoji(bot, callback, client, emoji)
+		return true
+	} else if strings.HasPrefix(data, "equip_emoji_") {
+		emoji := strings.TrimPrefix(data, "equip_emoji_")
+		handleEquipEmoji(bot, callback, client, emoji)
+		return true
+	}
+
+	return false
+}
+
+func showInventory(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery, client *mongo.Client) {
+	purchased, err := repository.GetPurchasedEmojis(client, int(callback.From.ID))
+	if err != nil {
+		bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, "Error loading inventory!"))
+		return
+	}
+
+	if len(purchased) == 0 {
+		bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, "Your inventory is empty! Buy some emojis first."))
+		return
+	}
+
+	equipped, err := repository.GetEquippedEmojis(client, int(callback.From.ID))
+	if err != nil {
+		bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, "Error loading equipped emojis!"))
+		return
+	}
+
+	equippedMap := make(map[string]bool)
+	for _, e := range equipped {
+		equippedMap[e] = true
+	}
+
+	var rows [][]tgbotapi.InlineKeyboardButton
+	var currentRow []tgbotapi.InlineKeyboardButton
+
+	for i, emoji := range purchased {
+		text := emoji
+		if equippedMap[emoji] {
+			text += " ✅"
+		}
+		btn := tgbotapi.NewInlineKeyboardButtonData(text, fmt.Sprintf("equip_emoji_%s", emoji))
+		currentRow = append(currentRow, btn)
+
+		if (i+1)%3 == 0 || i == len(purchased)-1 {
+			rows = append(rows, tgbotapi.NewInlineKeyboardRow(currentRow...))
+			currentRow = nil
+		}
+	}
+
+	markup := tgbotapi.NewInlineKeyboardMarkup(rows...)
+
+	editMsg := tgbotapi.NewEditMessageText(callback.Message.Chat.ID, callback.Message.MessageID, "🎒 *Your Inventory*\n\nTap an emoji to toggle (equip/unequip) it. It will appear next to your name in leaderboards!")
+	editMsg.ReplyMarkup = &markup
+	editMsg.ParseMode = "Markdown"
+	bot.Send(editMsg)
+
+	bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
+}
+
+func handleBuyEmoji(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery, client *mongo.Client, emoji string) {
+	var price int
+	for _, item := range service.ShopItems {
+		if item.Emoji == emoji {
+			price = item.Price
+			break
+		}
+	}
+
+	if price == 0 {
+		bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, "Emoji not found in shop!"))
+		return
+	}
+
+	purchased, _ := repository.GetPurchasedEmojis(client, int(callback.From.ID))
+	for _, e := range purchased {
+		if e == emoji {
+			bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, "You already own this emoji!"))
+			return
+		}
+	}
+
+	points := repository.GetCurrentPoints(client, int(callback.From.ID))
+	if points < price {
+		bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, fmt.Sprintf("Not enough points! You need %d points.", price)))
+		return
+	}
+
+	repository.DeductWordlePoints(client, int(callback.From.ID), callback.From.FirstName, callback.Message.Chat.ID, price)
+
+	err := repository.PurchaseEmoji(client, int(callback.From.ID), emoji)
+	if err != nil {
+		bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, "Error purchasing emoji! Please try again."))
+		return
+	}
+
+	bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, fmt.Sprintf("Successfully bought %s for %d points!", emoji, price)))
+
+	// Refresh shop view to potentially show new points or just state
+	showShop(bot, callback.Message.Chat.ID)
+}
+
+func handleEquipEmoji(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery, client *mongo.Client, emoji string) {
+	isEquipped, err := repository.ToggleEquipEmoji(client, int(callback.From.ID), emoji)
+	if err != nil {
+		bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, "Error toggling emoji!"))
+		return
+	}
+
+	status := "unequipped"
+	if isEquipped {
+		status = "equipped"
+	}
+
+	bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, fmt.Sprintf("%s has been %s!", emoji, status)))
+	showInventory(bot, callback, client)
+}

--- a/controller/categoryBot/shopUI.go
+++ b/controller/categoryBot/shopUI.go
@@ -1,0 +1,35 @@
+package categorybot
+
+import (
+	"fmt"
+	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/service"
+	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/view"
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+)
+
+func showShop(bot *tgbotapi.BotAPI, chatID int64) {
+	var rows [][]tgbotapi.InlineKeyboardButton
+
+	// Add inventory button
+	rows = append(rows, tgbotapi.NewInlineKeyboardRow(
+		tgbotapi.NewInlineKeyboardButtonData("🎒 My Inventory", "inventory"),
+	))
+
+	// Group emojis into rows of 3
+	var currentRow []tgbotapi.InlineKeyboardButton
+	for i, item := range service.ShopItems {
+		btn := tgbotapi.NewInlineKeyboardButtonData(
+			fmt.Sprintf("%s - %d 🪙", item.Emoji, item.Price),
+			fmt.Sprintf("buy_emoji_%s", item.Emoji),
+		)
+		currentRow = append(currentRow, btn)
+
+		if (i+1)%3 == 0 || i == len(service.ShopItems)-1 {
+			rows = append(rows, tgbotapi.NewInlineKeyboardRow(currentRow...))
+			currentRow = nil
+		}
+	}
+
+	markup := tgbotapi.NewInlineKeyboardMarkup(rows...)
+	view.SendMessageWithButtons(bot, chatID, "🛒 *Welcome to the Emoji Shop!*\n\nSpend your Wordle Points here to buy custom emojis that will appear next to your name on leaderboards.", markup)
+}

--- a/controller/shopCallback.go
+++ b/controller/shopCallback.go
@@ -1,0 +1,138 @@
+package controller
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/repository"
+	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/service"
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+func handleShopCallback(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery, client *mongo.Client) bool {
+	data := callback.Data
+
+	if data == "inventory" {
+		showInventory(bot, callback, client)
+		return true
+	} else if strings.HasPrefix(data, "buy_emoji_") {
+		emoji := strings.TrimPrefix(data, "buy_emoji_")
+		handleBuyEmoji(bot, callback, client, emoji)
+		return true
+	} else if strings.HasPrefix(data, "equip_emoji_") {
+		emoji := strings.TrimPrefix(data, "equip_emoji_")
+		handleEquipEmoji(bot, callback, client, emoji)
+		return true
+	}
+
+	return false
+}
+
+func showInventory(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery, client *mongo.Client) {
+	purchased, err := repository.GetPurchasedEmojis(client, int(callback.From.ID))
+	if err != nil {
+		bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, "Error loading inventory!"))
+		return
+	}
+
+	if len(purchased) == 0 {
+		bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, "Your inventory is empty! Buy some emojis first."))
+		return
+	}
+
+	equipped, err := repository.GetEquippedEmojis(client, int(callback.From.ID))
+	if err != nil {
+		bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, "Error loading equipped emojis!"))
+		return
+	}
+
+	equippedMap := make(map[string]bool)
+	for _, e := range equipped {
+		equippedMap[e] = true
+	}
+
+	var rows [][]tgbotapi.InlineKeyboardButton
+	var currentRow []tgbotapi.InlineKeyboardButton
+
+	for i, emoji := range purchased {
+		text := emoji
+		if equippedMap[emoji] {
+			text += " ✅"
+		}
+		btn := tgbotapi.NewInlineKeyboardButtonData(text, fmt.Sprintf("equip_emoji_%s", emoji))
+		currentRow = append(currentRow, btn)
+
+		if (i+1)%3 == 0 || i == len(purchased)-1 {
+			rows = append(rows, tgbotapi.NewInlineKeyboardRow(currentRow...))
+			currentRow = nil
+		}
+	}
+
+	markup := tgbotapi.NewInlineKeyboardMarkup(rows...)
+
+	editMsg := tgbotapi.NewEditMessageText(callback.Message.Chat.ID, callback.Message.MessageID, "🎒 *Your Inventory*\n\nTap an emoji to toggle (equip/unequip) it. It will appear next to your name in leaderboards!")
+	editMsg.ReplyMarkup = &markup
+	editMsg.ParseMode = "Markdown"
+	bot.Send(editMsg)
+
+	bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
+}
+
+func handleBuyEmoji(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery, client *mongo.Client, emoji string) {
+	var price int
+	for _, item := range service.ShopItems {
+		if item.Emoji == emoji {
+			price = item.Price
+			break
+		}
+	}
+
+	if price == 0 {
+		bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, "Emoji not found in shop!"))
+		return
+	}
+
+	purchased, _ := repository.GetPurchasedEmojis(client, int(callback.From.ID))
+	for _, e := range purchased {
+		if e == emoji {
+			bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, "You already own this emoji!"))
+			return
+		}
+	}
+
+	points := repository.GetCurrentPoints(client, int(callback.From.ID))
+	if points < price {
+		bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, fmt.Sprintf("Not enough points! You need %d points.", price)))
+		return
+	}
+
+	repository.DeductWordlePoints(client, int(callback.From.ID), callback.From.FirstName, callback.Message.Chat.ID, price)
+
+	err := repository.PurchaseEmoji(client, int(callback.From.ID), emoji)
+	if err != nil {
+		bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, "Error purchasing emoji! Please try again."))
+		return
+	}
+
+	bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, fmt.Sprintf("Successfully bought %s for %d points!", emoji, price)))
+
+	// Refresh shop view to potentially show new points or just state
+	showShop(bot, callback.Message.Chat.ID)
+}
+
+func handleEquipEmoji(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery, client *mongo.Client, emoji string) {
+	isEquipped, err := repository.ToggleEquipEmoji(client, int(callback.From.ID), emoji)
+	if err != nil {
+		bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, "Error toggling emoji!"))
+		return
+	}
+
+	status := "unequipped"
+	if isEquipped {
+		status = "equipped"
+	}
+
+	bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, fmt.Sprintf("%s has been %s!", emoji, status)))
+	showInventory(bot, callback, client)
+}

--- a/controller/shopUI.go
+++ b/controller/shopUI.go
@@ -1,0 +1,35 @@
+package controller
+
+import (
+	"fmt"
+	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/service"
+	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/view"
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+)
+
+func showShop(bot *tgbotapi.BotAPI, chatID int64) {
+	var rows [][]tgbotapi.InlineKeyboardButton
+
+	// Add inventory button
+	rows = append(rows, tgbotapi.NewInlineKeyboardRow(
+		tgbotapi.NewInlineKeyboardButtonData("🎒 My Inventory", "inventory"),
+	))
+
+	// Group emojis into rows of 3
+	var currentRow []tgbotapi.InlineKeyboardButton
+	for i, item := range service.ShopItems {
+		btn := tgbotapi.NewInlineKeyboardButtonData(
+			fmt.Sprintf("%s - %d 🪙", item.Emoji, item.Price),
+			fmt.Sprintf("buy_emoji_%s", item.Emoji),
+		)
+		currentRow = append(currentRow, btn)
+
+		if (i+1)%3 == 0 || i == len(service.ShopItems)-1 {
+			rows = append(rows, tgbotapi.NewInlineKeyboardRow(currentRow...))
+			currentRow = nil
+		}
+	}
+
+	markup := tgbotapi.NewInlineKeyboardMarkup(rows...)
+	view.SendMessageWithButtons(bot, chatID, "🛒 *Welcome to the Emoji Shop!*\n\nSpend your Wordle Points here to buy custom emojis that will appear next to your name on leaderboards.", markup)
+}

--- a/repository/dbManager.go
+++ b/repository/dbManager.go
@@ -351,3 +351,97 @@ func GetCurrentPoints(client *mongo.Client, userID int) int {
 func DeductWordlePoints(client *mongo.Client, userID int, name string, chatID int64, points int) {
 	InsertWordleBonusDoc(userID, name, chatID, client, "WordleEn", -points)
 }
+
+// GetEquippedEmojis returns the list of emojis equipped by a user
+func GetEquippedEmojis(client *mongo.Client, userID int) ([]string, error) {
+	database := client.Database("Telegram")
+	collection := database.Collection("UserEmojis")
+
+	filter := bson.M{"UserID": userID}
+	var result struct {
+		EquippedEmojis []string `bson:"EquippedEmojis"`
+	}
+
+	err := collection.FindOne(context.TODO(), filter).Decode(&result)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return []string{}, nil
+		}
+		return nil, err
+	}
+	return result.EquippedEmojis, nil
+}
+
+// GetPurchasedEmojis returns the list of emojis purchased by a user
+func GetPurchasedEmojis(client *mongo.Client, userID int) ([]string, error) {
+	database := client.Database("Telegram")
+	collection := database.Collection("UserEmojis")
+
+	filter := bson.M{"UserID": userID}
+	var result struct {
+		PurchasedEmojis []string `bson:"PurchasedEmojis"`
+	}
+
+	err := collection.FindOne(context.TODO(), filter).Decode(&result)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return []string{}, nil
+		}
+		return nil, err
+	}
+	return result.PurchasedEmojis, nil
+}
+
+// PurchaseEmoji adds an emoji to the user's purchased list
+func PurchaseEmoji(client *mongo.Client, userID int, emoji string) error {
+	database := client.Database("Telegram")
+	collection := database.Collection("UserEmojis")
+
+	filter := bson.M{"UserID": userID}
+	update := bson.M{
+		"$addToSet": bson.M{"PurchasedEmojis": emoji},
+	}
+
+	opts := options.Update().SetUpsert(true)
+	_, err := collection.UpdateOne(context.TODO(), filter, update, opts)
+	return err
+}
+
+// ToggleEquipEmoji toggles whether an emoji is equipped for a user
+func ToggleEquipEmoji(client *mongo.Client, userID int, emoji string) (bool, error) {
+	database := client.Database("Telegram")
+	collection := database.Collection("UserEmojis")
+
+	filter := bson.M{"UserID": userID}
+	var result struct {
+		EquippedEmojis []string `bson:"EquippedEmojis"`
+	}
+	err := collection.FindOne(context.TODO(), filter).Decode(&result)
+
+	isEquipped := false
+	if err == nil {
+		for _, e := range result.EquippedEmojis {
+			if e == emoji {
+				isEquipped = true
+				break
+			}
+		}
+	} else if err != mongo.ErrNoDocuments {
+		return false, err
+	}
+
+	var update bson.M
+	if isEquipped {
+		update = bson.M{"$pull": bson.M{"EquippedEmojis": emoji}}
+	} else {
+		update = bson.M{"$addToSet": bson.M{"EquippedEmojis": emoji}}
+	}
+
+	opts := options.Update().SetUpsert(true)
+	_, err = collection.UpdateOne(context.TODO(), filter, update, opts)
+	if err != nil {
+		return false, err
+	}
+
+	return !isEquipped, nil
+}

--- a/service/leaderBoardButtons.go
+++ b/service/leaderBoardButtons.go
@@ -3,6 +3,7 @@ package service
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/repository"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/view"
@@ -32,6 +33,24 @@ func LeaderBoardListButtons(client *mongo.Client, collection string, chatID int6
 	for i := 0; i < limit; i++ {
 		count := idCounts[i]
 		name := fmt.Sprintf("%v", count["Name"])
+
+		var userID int
+		if id, ok := count["_id"]; ok {
+			switch v := id.(type) {
+			case int32:
+				userID = int(v)
+			case int64:
+				userID = int(v)
+			case int:
+				userID = v
+			}
+		}
+
+		equippedEmojis, err := repository.GetEquippedEmojis(client, userID)
+		if err == nil && len(equippedEmojis) > 0 {
+			name += " " + strings.Join(equippedEmojis, "")
+		}
+
 		score := fmt.Sprintf("%v", count["count"])
 		if collection == "WordleEn" {
 			score += " 🪙"

--- a/service/leaderBoardList.go
+++ b/service/leaderBoardList.go
@@ -31,6 +31,25 @@ func LeaderBoardList(client *mongo.Client, collection string, chatID int64) stri
 	for i := 0; i < limit; i++ {
 		count := idCounts[i]
 		name := fmt.Sprintf("%v", count["Name"])
+
+		// Fetch and append equipped emojis to the user's name
+		var userID int
+		if id, ok := count["_id"]; ok {
+			switch v := id.(type) {
+			case int32:
+				userID = int(v)
+			case int64:
+				userID = int(v)
+			case int:
+				userID = v
+			}
+		}
+
+		equippedEmojis, err := repository.GetEquippedEmojis(client, userID)
+		if err == nil && len(equippedEmojis) > 0 {
+			name += " " + strings.Join(equippedEmojis, "")
+		}
+
 		score := fmt.Sprintf("%v", count["count"])
 		if collection == "WordleEn" {
 			score += " 🪙"
@@ -58,6 +77,12 @@ func GetUserStatsByID(client *mongo.Client, userID int) string {
 		stats = "No winning stats found"
 	} else {
 		name, _ := result["Name"].(string)
+
+		equippedEmojis, err := repository.GetEquippedEmojis(client, userID)
+		if err == nil && len(equippedEmojis) > 0 {
+			name += " " + strings.Join(equippedEmojis, "")
+		}
+
 		count, _ := result["count"].(int32)
 
 		stats = fmt.Sprintf("You %s have successfully guessed for:\n%d Times", name, count)
@@ -83,6 +108,12 @@ func GetWordleUserStatsByID(client *mongo.Client, userID int) string {
 		stats = "No winning stats found"
 	} else {
 		name, _ := result["Name"].(string)
+
+		equippedEmojis, err := repository.GetEquippedEmojis(client, userID)
+		if err == nil && len(equippedEmojis) > 0 {
+			name += " " + strings.Join(equippedEmojis, "")
+		}
+
 		count := 0
 		if val, ok := result["count"]; ok {
 			switch v := val.(type) {

--- a/service/shop.go
+++ b/service/shop.go
@@ -1,0 +1,18 @@
+package service
+
+type ShopItem struct {
+	Emoji string
+	Price int
+}
+
+var ShopItems = []ShopItem{
+	{"🦁", 100},
+	{"👑", 500},
+	{"🚀", 1000},
+	{"🔥", 200},
+	{"✨", 150},
+	{"💎", 2000},
+	{"🐊", 50},
+	{"⭐", 300},
+	{"😎", 250},
+}


### PR DESCRIPTION
This PR introduces an interactive `/shop` where users can spend their Wordle points to purchase and equip custom emojis.

Key changes:
- `service/shop.go`: Defines the emojis available and their prices.
- `controller/bot.go` and `controller/categoryBot/categoryBot.go`:
  - Handle the `/shop` command, redirecting group users to DM with a deep link (`t.me/BotUsername?start=shop`).
  - Added new callback query handling (`buy_emoji_*`, `equip_emoji_*`, `inventory`) to manage purchases.
- `repository/dbManager.go`: Added new functions utilizing `$addToSet` and `$pull` operators to fetch, purchase, and toggle the equip state of emojis atomically in a new `UserEmojis` collection.
- `service/leaderBoardList.go` and `service/leaderBoardButtons.go`: Now fetch a user's equipped emojis and append them to their names.

---
*PR created automatically by Jules for task [4691640028882946019](https://jules.google.com/task/4691640028882946019) started by @MUSTAFA-A-KHAN*