### PR TITLE
Fix inline button behavior for stats updates

### DIFF
--- a/controller/bot.go
+++ b/controller/bot.go
@@ -797,7 +797,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 	switch callback.Data {
 	case "statsglobal_wordguess":
 		markup := service.LeaderBoardListButtons(client, "CrocEn", 0)
-		err := view.SendMessageWithStyledButtons(bot.Token, chatID, "🏆 <b>Top 10 Players Leaderboard</b> 🏆\n\n✨ <b>Keep it up and aim for the top!</b> ✨", markup)
+		err := view.EditMessageTextWithStyledButtons(bot.Token, chatID, callback.Message.MessageID, "🏆 <b>Top 10 Players Leaderboard</b> 🏆\n\n✨ <b>Keep it up and aim for the top!</b> ✨", markup)
 		if err != nil {
 			log.Printf("Failed to send styled buttons message: %v", err)
 			view.SendMessagehtml(bot, chatID, "Failed to load leaderboard.")
@@ -806,7 +806,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		return
 	case "statsglobal_wordle":
 		markup := service.LeaderBoardListButtons(client, "WordleEn", 0)
-		err := view.SendMessageWithStyledButtons(bot.Token, chatID, "🏆 <b>Top 10 Players Leaderboard</b> 🏆\n\n✨ <b>Keep it up and aim for the top!</b> ✨", markup)
+		err := view.EditMessageTextWithStyledButtons(bot.Token, chatID, callback.Message.MessageID, "🏆 <b>Top 10 Players Leaderboard</b> 🏆\n\n✨ <b>Keep it up and aim for the top!</b> ✨", markup)
 		if err != nil {
 			log.Printf("Failed to send styled buttons message: %v", err)
 			view.SendMessagehtml(bot, chatID, "Failed to load leaderboard.")
@@ -815,7 +815,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		return
 	case "statsglobal_scramy":
 		markup := service.LeaderBoardListButtons(client, "ScramyEn", 0)
-		err := view.SendMessageWithStyledButtons(bot.Token, chatID, "🏆 <b>Top 10 Players Leaderboard</b> 🏆\n\n✨ <b>Keep it up and aim for the top!</b> ✨", markup)
+		err := view.EditMessageTextWithStyledButtons(bot.Token, chatID, callback.Message.MessageID, "🏆 <b>Top 10 Players Leaderboard</b> 🏆\n\n✨ <b>Keep it up and aim for the top!</b> ✨", markup)
 		if err != nil {
 			log.Printf("Failed to send styled buttons message: %v", err)
 			view.SendMessagehtml(bot, chatID, "Failed to load leaderboard.")
@@ -824,7 +824,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		return
 	case "statsgroup_wordguess":
 		markup := service.LeaderBoardListButtons(client, "CrocEn", chatID)
-		err := view.SendMessageWithStyledButtons(bot.Token, chatID, "🏆 <b>Top 10 Players Leaderboard</b> 🏆\n\n✨ <b>Keep it up and aim for the top!</b> ✨", markup)
+		err := view.EditMessageTextWithStyledButtons(bot.Token, chatID, callback.Message.MessageID, "🏆 <b>Top 10 Players Leaderboard</b> 🏆\n\n✨ <b>Keep it up and aim for the top!</b> ✨", markup)
 		if err != nil {
 			log.Printf("Failed to send styled buttons message: %v", err)
 			view.SendMessagehtml(bot, chatID, "Failed to load leaderboard.")
@@ -833,7 +833,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		return
 	case "statsgroup_wordle":
 		markup := service.LeaderBoardListButtons(client, "WordleEn", chatID)
-		err := view.SendMessageWithStyledButtons(bot.Token, chatID, "🏆 <b>Top 10 Players Leaderboard</b> 🏆\n\n✨ <b>Keep it up and aim for the top!</b> ✨", markup)
+		err := view.EditMessageTextWithStyledButtons(bot.Token, chatID, callback.Message.MessageID, "🏆 <b>Top 10 Players Leaderboard</b> 🏆\n\n✨ <b>Keep it up and aim for the top!</b> ✨", markup)
 		if err != nil {
 			log.Printf("Failed to send styled buttons message: %v", err)
 			view.SendMessagehtml(bot, chatID, "Failed to load leaderboard.")
@@ -842,7 +842,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		return
 	case "statsgroup_scramy":
 		markup := service.LeaderBoardListButtons(client, "ScramyEn", chatID)
-		err := view.SendMessageWithStyledButtons(bot.Token, chatID, "🏆 <b>Top 10 Players Leaderboard</b> 🏆\n\n✨ <b>Keep it up and aim for the top!</b> ✨", markup)
+		err := view.EditMessageTextWithStyledButtons(bot.Token, chatID, callback.Message.MessageID, "🏆 <b>Top 10 Players Leaderboard</b> 🏆\n\n✨ <b>Keep it up and aim for the top!</b> ✨", markup)
 		if err != nil {
 			log.Printf("Failed to send styled buttons message: %v", err)
 			view.SendMessagehtml(bot, chatID, "Failed to load leaderboard.")

--- a/controller/categoryBot/categoryBot.go
+++ b/controller/categoryBot/categoryBot.go
@@ -990,7 +990,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 	switch callback.Data {
 	case "statsglobal_wordguess":
 		markup := service.LeaderBoardListButtons(client, "CrocEn", 0)
-		err := view.SendMessageWithStyledButtons(bot.Token, chatID, "🏆 <b>Top 10 Players Leaderboard</b> 🏆\n\n✨ <b>Keep it up and aim for the top!</b> ✨", markup)
+		err := view.EditMessageTextWithStyledButtons(bot.Token, chatID, callback.Message.MessageID, "🏆 <b>Top 10 Players Leaderboard</b> 🏆\n\n✨ <b>Keep it up and aim for the top!</b> ✨", markup)
 		if err != nil {
 			log.Printf("Failed to send styled buttons message: %v", err)
 			view.SendMessagehtml(bot, chatID, "Failed to load leaderboard.")
@@ -999,7 +999,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		return
 	case "statsglobal_wordle":
 		markup := service.LeaderBoardListButtons(client, "WordleEn", 0)
-		err := view.SendMessageWithStyledButtons(bot.Token, chatID, "🏆 <b>Top 10 Players Leaderboard</b> 🏆\n\n✨ <b>Keep it up and aim for the top!</b> ✨", markup)
+		err := view.EditMessageTextWithStyledButtons(bot.Token, chatID, callback.Message.MessageID, "🏆 <b>Top 10 Players Leaderboard</b> 🏆\n\n✨ <b>Keep it up and aim for the top!</b> ✨", markup)
 		if err != nil {
 			log.Printf("Failed to send styled buttons message: %v", err)
 			view.SendMessagehtml(bot, chatID, "Failed to load leaderboard.")
@@ -1008,7 +1008,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		return
 	case "statsglobal_scramy":
 		markup := service.LeaderBoardListButtons(client, "ScramyEn", 0)
-		err := view.SendMessageWithStyledButtons(bot.Token, chatID, "🏆 <b>Top 10 Players Leaderboard</b> 🏆\n\n✨ <b>Keep it up and aim for the top!</b> ✨", markup)
+		err := view.EditMessageTextWithStyledButtons(bot.Token, chatID, callback.Message.MessageID, "🏆 <b>Top 10 Players Leaderboard</b> 🏆\n\n✨ <b>Keep it up and aim for the top!</b> ✨", markup)
 		if err != nil {
 			log.Printf("Failed to send styled buttons message: %v", err)
 			view.SendMessagehtml(bot, chatID, "Failed to load leaderboard.")
@@ -1017,7 +1017,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		return
 	case "statsgroup_wordguess":
 		markup := service.LeaderBoardListButtons(client, "CrocEn", chatID)
-		err := view.SendMessageWithStyledButtons(bot.Token, chatID, "🏆 <b>Top 10 Players Leaderboard</b> 🏆\n\n✨ <b>Keep it up and aim for the top!</b> ✨", markup)
+		err := view.EditMessageTextWithStyledButtons(bot.Token, chatID, callback.Message.MessageID, "🏆 <b>Top 10 Players Leaderboard</b> 🏆\n\n✨ <b>Keep it up and aim for the top!</b> ✨", markup)
 		if err != nil {
 			log.Printf("Failed to send styled buttons message: %v", err)
 			view.SendMessagehtml(bot, chatID, "Failed to load leaderboard.")
@@ -1026,7 +1026,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		return
 	case "statsgroup_wordle":
 		markup := service.LeaderBoardListButtons(client, "WordleEn", chatID)
-		err := view.SendMessageWithStyledButtons(bot.Token, chatID, "🏆 <b>Top 10 Players Leaderboard</b> 🏆\n\n✨ <b>Keep it up and aim for the top!</b> ✨", markup)
+		err := view.EditMessageTextWithStyledButtons(bot.Token, chatID, callback.Message.MessageID, "🏆 <b>Top 10 Players Leaderboard</b> 🏆\n\n✨ <b>Keep it up and aim for the top!</b> ✨", markup)
 		if err != nil {
 			log.Printf("Failed to send styled buttons message: %v", err)
 			view.SendMessagehtml(bot, chatID, "Failed to load leaderboard.")
@@ -1035,7 +1035,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		return
 	case "statsgroup_scramy":
 		markup := service.LeaderBoardListButtons(client, "ScramyEn", chatID)
-		err := view.SendMessageWithStyledButtons(bot.Token, chatID, "🏆 <b>Top 10 Players Leaderboard</b> 🏆\n\n✨ <b>Keep it up and aim for the top!</b> ✨", markup)
+		err := view.EditMessageTextWithStyledButtons(bot.Token, chatID, callback.Message.MessageID, "🏆 <b>Top 10 Players Leaderboard</b> 🏆\n\n✨ <b>Keep it up and aim for the top!</b> ✨", markup)
 		if err != nil {
 			log.Printf("Failed to send styled buttons message: %v", err)
 			view.SendMessagehtml(bot, chatID, "Failed to load leaderboard.")

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,16 @@
+1. **Add `EditMessageTextWithStyledButtons` to `view/custom_http.go`**
+   - Create a new struct `EditMessageRequest` with `ChatID`, `MessageID`, `Text`, `ParseMode`, and `ReplyMarkup`.
+   - Implement `EditMessageTextWithStyledButtons` similarly to `SendMessageWithStyledButtons` but targeting the `/editMessageText` Telegram API endpoint.
+
+2. **Update `handleCallbackQuery` in `controller/bot.go`**
+   - For callback data cases `statsglobal_*` and `statsgroup_*`, replace `view.SendMessageWithStyledButtons` with `view.EditMessageTextWithStyledButtons`.
+   - Pass `callback.Message.MessageID` to the new function.
+
+3. **Update `handleCallbackQuery` in `controller/categoryBot/categoryBot.go`**
+   - Apply the same changes as above for consistency across bot controllers.
+
+4. **Run Pre-Commit Checks**
+   - Execute all checks to ensure proper testing, verification, review, and reflection are done.
+
+5. **Commit and Submit**
+   - Submit the changes using the `submit` tool.

--- a/view/custom_http.go
+++ b/view/custom_http.go
@@ -26,11 +26,52 @@ type SendMessageRequest struct {
 	ReplyMarkup *CustomInlineKeyboardMarkup `json:"reply_markup,omitempty"`
 }
 
+type EditMessageRequest struct {
+	ChatID      int64                       `json:"chat_id"`
+	MessageID   int                         `json:"message_id"`
+	Text        string                      `json:"text"`
+	ParseMode   string                      `json:"parse_mode,omitempty"`
+	ReplyMarkup *CustomInlineKeyboardMarkup `json:"reply_markup,omitempty"`
+}
+
 func SendMessageWithStyledButtons(botToken string, chatID int64, text string, markup *CustomInlineKeyboardMarkup) error {
 	url := fmt.Sprintf("https://api.telegram.org/bot%s/sendMessage", botToken)
 
 	reqBody := SendMessageRequest{
 		ChatID:      chatID,
+		Text:        text,
+		ParseMode:   "HTML",
+		ReplyMarkup: markup,
+	}
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		log.Printf("failed to marshal request: %v", err)
+		return fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	resp, err := http.Post(url, "application/json", bytes.NewBuffer(jsonData))
+	if err != nil {
+		log.Printf("failed to send request: %v", err)
+		return fmt.Errorf("failed to send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		log.Printf("Telegram API responded with status: %s, body: %s", resp.Status, string(bodyBytes))
+		return fmt.Errorf("Telegram API responded with status: %s", resp.Status)
+	}
+
+	return nil
+}
+
+func EditMessageTextWithStyledButtons(botToken string, chatID int64, messageID int, text string, markup *CustomInlineKeyboardMarkup) error {
+	url := fmt.Sprintf("https://api.telegram.org/bot%s/editMessageText", botToken)
+
+	reqBody := EditMessageRequest{
+		ChatID:      chatID,
+		MessageID:   messageID,
 		Text:        text,
 		ParseMode:   "HTML",
 		ReplyMarkup: markup,


### PR DESCRIPTION
Replaced `SendMessageWithStyledButtons` with `EditMessageTextWithStyledButtons` for `/stats` inline callbacks so the bot updates the current message inline rather than spamming new messages.

---
*PR created automatically by Jules for task [13949137108199568773](https://jules.google.com/task/13949137108199568773) started by @MUSTAFA-A-KHAN*