### PR TITLE
🎨 Palette: Add Back to Shop navigation in inventory view

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-03 - [Back Button Navigation in Telegram Bot UIs]
+**Learning:** Conversational interfaces like Telegram bots often trap users in deep sub-menus (e.g., an "Inventory" menu branching off a "Shop" main menu) if explicit backwards navigation is not provided. Furthermore, modifying the current active menu by editing the message `tgbotapi.NewEditMessageText` creates a cleaner, more intuitive interaction flow compared to sending entirely new messages that clutter the chat feed.
+**Action:** Always include a "🔙 Back" button in inline keyboards for deeper navigational menus to let users return to the parent context seamlessly. Combine this with message editing rather than resending to prevent feed spamming and keep the UX responsive.

--- a/controller/categoryBot/shopCallback.go
+++ b/controller/categoryBot/shopCallback.go
@@ -16,6 +16,9 @@ func handleShopCallback(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery, 
 	if data == "inventory" {
 		showInventory(bot, callback, client)
 		return true
+	} else if data == "shop_main" {
+		editShopMain(bot, callback)
+		return true
 	} else if strings.HasPrefix(data, "buy_emoji_") {
 		emoji := strings.TrimPrefix(data, "buy_emoji_")
 		handleBuyEmoji(bot, callback, client, emoji)
@@ -27,6 +30,39 @@ func handleShopCallback(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery, 
 	}
 
 	return false
+}
+
+func editShopMain(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery) {
+	var rows [][]tgbotapi.InlineKeyboardButton
+
+	// Add inventory button
+	rows = append(rows, tgbotapi.NewInlineKeyboardRow(
+		tgbotapi.NewInlineKeyboardButtonData("🎒 My Inventory", "inventory"),
+	))
+
+	// Group emojis into rows of 3
+	var currentRow []tgbotapi.InlineKeyboardButton
+	for i, item := range service.ShopItems {
+		btn := tgbotapi.NewInlineKeyboardButtonData(
+			fmt.Sprintf("%s - %d 🪙", item.Emoji, item.Price),
+			fmt.Sprintf("buy_emoji_%s", item.Emoji),
+		)
+		currentRow = append(currentRow, btn)
+
+		if (i+1)%3 == 0 || i == len(service.ShopItems)-1 {
+			rows = append(rows, tgbotapi.NewInlineKeyboardRow(currentRow...))
+			currentRow = nil
+		}
+	}
+
+	markup := tgbotapi.NewInlineKeyboardMarkup(rows...)
+
+	editMsg := tgbotapi.NewEditMessageText(callback.Message.Chat.ID, callback.Message.MessageID, "🛒 *Welcome to the Emoji Shop!*\n\nSpend your Wordle Points here to buy custom emojis that will appear next to your name on leaderboards.")
+	editMsg.ReplyMarkup = &markup
+	editMsg.ParseMode = "Markdown"
+	bot.Send(editMsg)
+
+	bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
 }
 
 func showInventory(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery, client *mongo.Client) {
@@ -68,6 +104,10 @@ func showInventory(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery, clien
 			currentRow = nil
 		}
 	}
+
+	rows = append(rows, tgbotapi.NewInlineKeyboardRow(
+		tgbotapi.NewInlineKeyboardButtonData("🔙 Back to Shop", "shop_main"),
+	))
 
 	markup := tgbotapi.NewInlineKeyboardMarkup(rows...)
 

--- a/controller/shopCallback.go
+++ b/controller/shopCallback.go
@@ -16,6 +16,9 @@ func handleShopCallback(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery, 
 	if data == "inventory" {
 		showInventory(bot, callback, client)
 		return true
+	} else if data == "shop_main" {
+		editShopMain(bot, callback)
+		return true
 	} else if strings.HasPrefix(data, "buy_emoji_") {
 		emoji := strings.TrimPrefix(data, "buy_emoji_")
 		handleBuyEmoji(bot, callback, client, emoji)
@@ -27,6 +30,39 @@ func handleShopCallback(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery, 
 	}
 
 	return false
+}
+
+func editShopMain(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery) {
+	var rows [][]tgbotapi.InlineKeyboardButton
+
+	// Add inventory button
+	rows = append(rows, tgbotapi.NewInlineKeyboardRow(
+		tgbotapi.NewInlineKeyboardButtonData("🎒 My Inventory", "inventory"),
+	))
+
+	// Group emojis into rows of 3
+	var currentRow []tgbotapi.InlineKeyboardButton
+	for i, item := range service.ShopItems {
+		btn := tgbotapi.NewInlineKeyboardButtonData(
+			fmt.Sprintf("%s - %d 🪙", item.Emoji, item.Price),
+			fmt.Sprintf("buy_emoji_%s", item.Emoji),
+		)
+		currentRow = append(currentRow, btn)
+
+		if (i+1)%3 == 0 || i == len(service.ShopItems)-1 {
+			rows = append(rows, tgbotapi.NewInlineKeyboardRow(currentRow...))
+			currentRow = nil
+		}
+	}
+
+	markup := tgbotapi.NewInlineKeyboardMarkup(rows...)
+
+	editMsg := tgbotapi.NewEditMessageText(callback.Message.Chat.ID, callback.Message.MessageID, "🛒 *Welcome to the Emoji Shop!*\n\nSpend your Wordle Points here to buy custom emojis that will appear next to your name on leaderboards.")
+	editMsg.ReplyMarkup = &markup
+	editMsg.ParseMode = "Markdown"
+	bot.Send(editMsg)
+
+	bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
 }
 
 func showInventory(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery, client *mongo.Client) {
@@ -68,6 +104,10 @@ func showInventory(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery, clien
 			currentRow = nil
 		}
 	}
+
+	rows = append(rows, tgbotapi.NewInlineKeyboardRow(
+		tgbotapi.NewInlineKeyboardButtonData("🔙 Back to Shop", "shop_main"),
+	))
 
 	markup := tgbotapi.NewInlineKeyboardMarkup(rows...)
 


### PR DESCRIPTION
💡 What: Added a "🔙 Back to Shop" button in the inventory view, and added a handler to seamlessly edit the message back to the main shop menu.
🎯 Why: Deep menus without back navigation trap users. This prevents users from having to retype the `/shop` command and keeps the chat clean by editing the existing message instead of sending a new one.
📸 Before/After: Visual changes to the Telegram bot inline keyboard.
♿ Accessibility: Improves navigation accessibility within the conversational bot interface.

---
*PR created automatically by Jules for task [3306138573272790688](https://jules.google.com/task/3306138573272790688) started by @MUSTAFA-A-KHAN*