### PR TITLE
Add "Custom Word" deep-link feature in DM for group leaders

### DIFF
--- a/controller/bot.go
+++ b/controller/bot.go
@@ -231,6 +231,7 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 			args := message.CommandArguments()
 			if args == "shop" {
 				showShop(bot, message.Chat.ID)
+				return
 			} else if strings.HasPrefix(args, "custom_word_") {
 				parts := strings.Split(args, "_")
 				if len(parts) == 3 {
@@ -251,10 +252,12 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 						}
 					}
 				}
+				return
 			} else {
 				buttons := tgbotapi.NewInlineKeyboardMarkup(
 					tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Get Hint"+telegramReactions[20], "hint")))
 				view.SendMessageWithButtons(bot, message.Chat.ID, "Heyyy! Got a word for ya 😏 Tap the button below if you need a lil hint 👇", buttons)
+				return
 			}
 		case "exportdata":
 			if message.From.ID != int(adminID) {
@@ -495,34 +498,37 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 		groupChatID, ok := customWordState[int64(message.From.ID)]
 		customWordMutex.Unlock()
 		if ok && message.Chat.IsPrivate() {
-			if message.Text == "/cancel" {
+			if message.Command() == "cancel" {
 				customWordMutex.Lock()
 				delete(customWordState, int64(message.From.ID))
 				customWordMutex.Unlock()
 				view.SendMessage(bot, chatID, "Custom word entry cancelled.")
 				return
 			}
-			cleanWord := strings.TrimSpace(message.Text)
-			if validator.IsValidWord(cleanWord) {
-				groupState := getOrCreateChatState(groupChatID)
-				groupState.Lock()
-				if groupState.User == message.From.ID {
-					groupState.Word = strings.ToUpper(cleanWord)
-					customWordMutex.Lock()
-					delete(customWordState, int64(message.From.ID))
-					customWordMutex.Unlock()
-					view.SendMessage(bot, chatID, fmt.Sprintf("Your custom word '%s' has been set for the group!", cleanWord))
+
+			if !message.IsCommand() {
+				cleanWord := strings.TrimSpace(message.Text)
+				if validator.IsValidWord(cleanWord) {
+					groupState := getOrCreateChatState(groupChatID)
+					groupState.Lock()
+					if groupState.User == message.From.ID {
+						groupState.Word = strings.ToUpper(cleanWord)
+						customWordMutex.Lock()
+						delete(customWordState, int64(message.From.ID))
+						customWordMutex.Unlock()
+						view.SendMessage(bot, chatID, fmt.Sprintf("Your custom word '%s' has been set for the group!", cleanWord))
+					} else {
+						customWordMutex.Lock()
+						delete(customWordState, int64(message.From.ID))
+						customWordMutex.Unlock()
+						view.SendMessage(bot, chatID, "You are no longer the leader of the group, so you cannot set the word.")
+					}
+					groupState.Unlock()
 				} else {
-					customWordMutex.Lock()
-					delete(customWordState, int64(message.From.ID))
-					customWordMutex.Unlock()
-					view.SendMessage(bot, chatID, "You are no longer the leader of the group, so you cannot set the word.")
+					view.SendMessage(bot, chatID, "Invalid word. Please send a valid English word. Or type /cancel to abort.")
 				}
-				groupState.Unlock()
-			} else {
-				view.SendMessage(bot, chatID, "Invalid word. Please send a valid English word. Or type /cancel to abort.")
+				return
 			}
-			return
 		}
 
 		// Check if Wordle is active for DM

--- a/controller/bot.go
+++ b/controller/bot.go
@@ -13,6 +13,7 @@ import (
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/scramybot"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/wordlebot"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/model"
+	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/model/validator"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/repository"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/service"
 	installOllama "github.com/MUSTAFA-A-KHAN/telegram-bot-anime/service/installOllama"
@@ -173,6 +174,9 @@ func StartBot(token string) error {
 var aiModeUsers = make(map[int64]bool)
 var aiModeMutex = &sync.Mutex{}
 
+var customWordState = make(map[int64]int64)
+var customWordMutex = &sync.Mutex{}
+
 // handleMessage processes incoming messages and handles commands and guesses.
 func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mongo.Client) {
 	chatID := message.Chat.ID
@@ -224,8 +228,29 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 			button := tgbotapi.NewInlineKeyboardButtonURL("add to group", "https://t.me/Croco_rebirth_bot?startgroup=true")
 			view.SendMessageWithKeyboardButton(bot, chatID, "Unlock my full potential by adding me to a group chat!", button)
 		case "start":
-			if message.CommandArguments() == "shop" {
+			args := message.CommandArguments()
+			if args == "shop" {
 				showShop(bot, message.Chat.ID)
+			} else if strings.HasPrefix(args, "custom_word_") {
+				parts := strings.Split(args, "_")
+				if len(parts) == 3 {
+					groupChatIDStr := parts[2]
+					var groupChatID int64
+					if _, err := fmt.Sscanf(groupChatIDStr, "%d", &groupChatID); err == nil {
+						groupState := getOrCreateChatState(groupChatID)
+						groupState.RLock()
+						isLeader := groupState.User == message.From.ID
+						groupState.RUnlock()
+						if isLeader {
+							customWordMutex.Lock()
+							customWordState[int64(message.From.ID)] = groupChatID
+							customWordMutex.Unlock()
+							view.SendMessage(bot, chatID, "Type the word you want the group to guess (must be a valid English word):")
+						} else {
+							view.SendMessage(bot, chatID, "You are not the current leader in that group.")
+						}
+					}
+				}
 			} else {
 				buttons := tgbotapi.NewInlineKeyboardMarkup(
 					tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Get Hint"+telegramReactions[20], "hint")))
@@ -461,6 +486,41 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 			} else {
 				sentMsg, err := view.SendMessage(bot, chatID, "Please try to read the hint before revealing the word.")
 				deleteWarningMessage(bot, message, sentMsg, err)
+			}
+			return
+		}
+
+		// Check if user is in custom word state
+		customWordMutex.Lock()
+		groupChatID, ok := customWordState[int64(message.From.ID)]
+		customWordMutex.Unlock()
+		if ok && message.Chat.IsPrivate() {
+			if message.Text == "/cancel" {
+				customWordMutex.Lock()
+				delete(customWordState, int64(message.From.ID))
+				customWordMutex.Unlock()
+				view.SendMessage(bot, chatID, "Custom word entry cancelled.")
+				return
+			}
+			cleanWord := strings.TrimSpace(message.Text)
+			if validator.IsValidWord(cleanWord) {
+				groupState := getOrCreateChatState(groupChatID)
+				groupState.Lock()
+				if groupState.User == message.From.ID {
+					groupState.Word = strings.ToUpper(cleanWord)
+					customWordMutex.Lock()
+					delete(customWordState, int64(message.From.ID))
+					customWordMutex.Unlock()
+					view.SendMessage(bot, chatID, fmt.Sprintf("Your custom word '%s' has been set for the group!", cleanWord))
+				} else {
+					customWordMutex.Lock()
+					delete(customWordState, int64(message.From.ID))
+					customWordMutex.Unlock()
+					view.SendMessage(bot, chatID, "You are no longer the leader of the group, so you cannot set the word.")
+				}
+				groupState.Unlock()
+			} else {
+				view.SendMessage(bot, chatID, "Invalid word. Please send a valid English word. Or type /cancel to abort.")
 			}
 			return
 		}
@@ -911,9 +971,13 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 				chatState.Unlock()
 				return
 			}
+			customWordLink := fmt.Sprintf("https://t.me/%s?start=custom_word_%d", bot.Self.UserName, chatID)
 			buttons := tgbotapi.NewInlineKeyboardMarkup(
 				tgbotapi.NewInlineKeyboardRow(
 					tgbotapi.NewInlineKeyboardButtonData("See word 👀", "explain"),
+				),
+				tgbotapi.NewInlineKeyboardRow(
+					tgbotapi.NewInlineKeyboardButtonURL("Custom Word ✍️", customWordLink),
 				),
 				tgbotapi.NewInlineKeyboardRow(
 					tgbotapi.NewInlineKeyboardButtonData("Next ⏭️", "next"),

--- a/controller/categoryBot/categoryBot.go
+++ b/controller/categoryBot/categoryBot.go
@@ -295,6 +295,7 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 			args := message.CommandArguments()
 			if args == "shop" {
 				showShop(bot, message.Chat.ID)
+				return
 			} else if strings.HasPrefix(args, "custom_word_") {
 				parts := strings.Split(args, "_")
 				if len(parts) == 3 {
@@ -315,10 +316,12 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 						}
 					}
 				}
+				return
 			} else {
 				buttons := tgbotapi.NewInlineKeyboardMarkup(
 					tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Get Hint"+telegramReactions[20], "hint")))
 				view.SendMessageWithButtons(bot, message.Chat.ID, "Heyyy! Got a word for ya 😏 Tap the button below if you need a lil hint 👇", buttons)
+				return
 			}
 		case "wordle":
 			wordlebot.HandleWordleCommand(bot, chatID, message.From.FirstName)
@@ -587,34 +590,37 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 		groupChatID, ok := customWordState[int64(message.From.ID)]
 		customWordMutex.Unlock()
 		if ok && message.Chat.IsPrivate() {
-			if message.Text == "/cancel" {
+			if message.Command() == "cancel" {
 				customWordMutex.Lock()
 				delete(customWordState, int64(message.From.ID))
 				customWordMutex.Unlock()
 				view.SendMessage(bot, chatID, "Custom word entry cancelled.")
 				return
 			}
-			cleanWord := strings.TrimSpace(message.Text)
-			if validator.IsValidWord(cleanWord) {
-				groupState := getOrCreateChatState(groupChatID)
-				groupState.Lock()
-				if groupState.User == message.From.ID {
-					groupState.Word = strings.ToUpper(cleanWord)
-					customWordMutex.Lock()
-					delete(customWordState, int64(message.From.ID))
-					customWordMutex.Unlock()
-					view.SendMessage(bot, chatID, fmt.Sprintf("Your custom word '%s' has been set for the group!", cleanWord))
+
+			if !message.IsCommand() {
+				cleanWord := strings.TrimSpace(message.Text)
+				if validator.IsValidWord(cleanWord) {
+					groupState := getOrCreateChatState(groupChatID)
+					groupState.Lock()
+					if groupState.User == message.From.ID {
+						groupState.Word = strings.ToUpper(cleanWord)
+						customWordMutex.Lock()
+						delete(customWordState, int64(message.From.ID))
+						customWordMutex.Unlock()
+						view.SendMessage(bot, chatID, fmt.Sprintf("Your custom word '%s' has been set for the group!", cleanWord))
+					} else {
+						customWordMutex.Lock()
+						delete(customWordState, int64(message.From.ID))
+						customWordMutex.Unlock()
+						view.SendMessage(bot, chatID, "You are no longer the leader of the group, so you cannot set the word.")
+					}
+					groupState.Unlock()
 				} else {
-					customWordMutex.Lock()
-					delete(customWordState, int64(message.From.ID))
-					customWordMutex.Unlock()
-					view.SendMessage(bot, chatID, "You are no longer the leader of the group, so you cannot set the word.")
+					view.SendMessage(bot, chatID, "Invalid word. Please send a valid English word. Or type /cancel to abort.")
 				}
-				groupState.Unlock()
-			} else {
-				view.SendMessage(bot, chatID, "Invalid word. Please send a valid English word. Or type /cancel to abort.")
+				return
 			}
-			return
 		}
 
 		// Check if Wordle is active for DM

--- a/controller/categoryBot/categoryBot.go
+++ b/controller/categoryBot/categoryBot.go
@@ -14,6 +14,7 @@ import (
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/scramybot"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/wordlebot"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/model"
+	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/model/validator"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/repository"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/service"
 	installOllama "github.com/MUSTAFA-A-KHAN/telegram-bot-anime/service/installOllama"
@@ -146,11 +147,13 @@ func createSingleButtonKeyboard(text, data string) tgbotapi.InlineKeyboardMarkup
 	)
 }
 
-func createCategoryBotKeyboard() tgbotapi.InlineKeyboardMarkup {
+func createCategoryBotKeyboard(botUsername string, chatID int64) tgbotapi.InlineKeyboardMarkup {
+	customWordLink := fmt.Sprintf("https://t.me/%s?start=custom_word_%d", botUsername, chatID)
 	return tgbotapi.NewInlineKeyboardMarkup(
 		// First line with a single button
 		tgbotapi.NewInlineKeyboardRow(
 			tgbotapi.NewInlineKeyboardButtonData("See word 👀", "explain"),
+			tgbotapi.NewInlineKeyboardButtonURL("Custom Word ✍️", customWordLink),
 		),
 		// Second line with multiple buttons
 		tgbotapi.NewInlineKeyboardRow(
@@ -235,6 +238,9 @@ func StartBot(token string) error {
 var aiModeUsers = make(map[int64]bool)
 var aiModeMutex = &sync.Mutex{}
 
+var customWordState = make(map[int64]int64)
+var customWordMutex = &sync.Mutex{}
+
 // handleMessage processes incoming messages and handles commands and guesses.
 func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mongo.Client) {
 	chatID := message.Chat.ID
@@ -286,8 +292,29 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 			button := tgbotapi.NewInlineKeyboardButtonURL("add to group", "https://t.me/Croco_rebirth_bot?startgroup=true")
 			view.SendMessageWithKeyboardButton(bot, chatID, "Unlock my full potential by adding me to a group chat!", button)
 		case "start":
-			if message.CommandArguments() == "shop" {
+			args := message.CommandArguments()
+			if args == "shop" {
 				showShop(bot, message.Chat.ID)
+			} else if strings.HasPrefix(args, "custom_word_") {
+				parts := strings.Split(args, "_")
+				if len(parts) == 3 {
+					groupChatIDStr := parts[2]
+					var groupChatID int64
+					if _, err := fmt.Sscanf(groupChatIDStr, "%d", &groupChatID); err == nil {
+						groupState := getOrCreateChatState(groupChatID)
+						groupState.RLock()
+						isLeader := groupState.User == message.From.ID
+						groupState.RUnlock()
+						if isLeader {
+							customWordMutex.Lock()
+							customWordState[int64(message.From.ID)] = groupChatID
+							customWordMutex.Unlock()
+							view.SendMessage(bot, chatID, "Type the word you want the group to guess (must be a valid English word):")
+						} else {
+							view.SendMessage(bot, chatID, "You are not the current leader in that group.")
+						}
+					}
+				}
 			} else {
 				buttons := tgbotapi.NewInlineKeyboardMarkup(
 					tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Get Hint"+telegramReactions[20], "hint")))
@@ -551,6 +578,41 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 			} else {
 				sentMsg, err := view.SendMessage(bot, chatID, "Please try to read the hint before revealing the word.")
 				deleteWarningMessage(bot, message, sentMsg, err)
+			}
+			return
+		}
+
+		// Check if user is in custom word state
+		customWordMutex.Lock()
+		groupChatID, ok := customWordState[int64(message.From.ID)]
+		customWordMutex.Unlock()
+		if ok && message.Chat.IsPrivate() {
+			if message.Text == "/cancel" {
+				customWordMutex.Lock()
+				delete(customWordState, int64(message.From.ID))
+				customWordMutex.Unlock()
+				view.SendMessage(bot, chatID, "Custom word entry cancelled.")
+				return
+			}
+			cleanWord := strings.TrimSpace(message.Text)
+			if validator.IsValidWord(cleanWord) {
+				groupState := getOrCreateChatState(groupChatID)
+				groupState.Lock()
+				if groupState.User == message.From.ID {
+					groupState.Word = strings.ToUpper(cleanWord)
+					customWordMutex.Lock()
+					delete(customWordState, int64(message.From.ID))
+					customWordMutex.Unlock()
+					view.SendMessage(bot, chatID, fmt.Sprintf("Your custom word '%s' has been set for the group!", cleanWord))
+				} else {
+					customWordMutex.Lock()
+					delete(customWordState, int64(message.From.ID))
+					customWordMutex.Unlock()
+					view.SendMessage(bot, chatID, "You are no longer the leader of the group, so you cannot set the word.")
+				}
+				groupState.Unlock()
+			} else {
+				view.SendMessage(bot, chatID, "Invalid word. Please send a valid English word. Or type /cancel to abort.")
 			}
 			return
 		}
@@ -1076,7 +1138,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 				chatState.Unlock()
 				return
 			}
-			buttons := createCategoryBotKeyboard()
+			buttons := createCategoryBotKeyboard(bot.Self.UserName, chatID)
 			chatState.Word = word
 			view.SendMessageWithButtons(bot, callback.Message.Chat.ID, fmt.Sprintf(" [%s](tg://user?id=%d) is explaining the word!", callback.From.FirstName, callback.From.ID), buttons)
 

--- a/model/validator/validator.go
+++ b/model/validator/validator.go
@@ -1,0 +1,44 @@
+package validator
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+var (
+	ValidCustomWords map[string]bool
+)
+
+func init() {
+	ValidCustomWords = make(map[string]bool)
+	loadWords("controller/translator/words.txt")
+	loadWords("controller/translator/allowed_words.txt")
+}
+
+func loadWords(filePath string) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		fmt.Printf("Warning: Could not open word file %s: %v\n", filePath, err)
+		// Try falling back to parent directory if running from subdirectory (e.g. tests)
+		file, err = os.Open("../" + filePath)
+		if err != nil {
+			fmt.Printf("Warning: Could not open word file ../%s: %v\n", filePath, err)
+			return
+		}
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		word := strings.TrimSpace(scanner.Text())
+		if word != "" {
+			ValidCustomWords[strings.ToUpper(word)] = true
+		}
+	}
+}
+
+func IsValidWord(word string) bool {
+	return ValidCustomWords[strings.ToUpper(word)]
+}

--- a/model/validator/validator.go
+++ b/model/validator/validator.go
@@ -15,6 +15,8 @@ func init() {
 	ValidCustomWords = make(map[string]bool)
 	loadWords("controller/translator/words.txt")
 	loadWords("controller/translator/allowed_words.txt")
+	loadWords("controller/translator/scramy_words.txt")
+	loadWords("controller/translator/scramy_allowed_words.txt")
 }
 
 func loadWords(filePath string) {


### PR DESCRIPTION
This commit introduces a new feature allowing group leaders to set custom secret words via Direct Messages (DMs). A "Custom Word" inline button uses deep linking to redirect the leader from the group to the bot's DM. A state map (`customWordState`) is implemented with mutexes to safely track which user is setting a word for which group. The word is rigorously checked against the newly created centralized `model/validator` dictionary. Full synchronization controls (`groupState.Lock`) verify that the user remains the current leader before applying the custom word to prevent race conditions or abuse. It also includes an escape hatch `/cancel` for the DM state.

---
*PR created automatically by Jules for task [12817856535181747968](https://jules.google.com/task/12817856535181747968) started by @MUSTAFA-A-KHAN*