### PR TITLE
feat: Persist game states in MongoDB to survive restarts

### DIFF
--- a/controller/bot.go
+++ b/controller/bot.go
@@ -22,6 +22,39 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
+// ChatStateDoc is the MongoDB-serializable version of ChatState
+type ChatStateDoc struct {
+	ChatID            int64     `bson:"_id"`
+	Word              string    `bson:"word"`
+	User              int       `bson:"user"`
+	LeadTimestamp     time.Time `bson:"lead_timestamp"`
+	Leader            string    `bson:"leader"`
+	LastHintTimestamp time.Time `bson:"last_hint_timestamp"`
+	LastHintTypeSent  int       `bson:"last_hint_type_sent"`
+}
+
+// saveChatStateAsync asynchronously saves a chat state to MongoDB.
+func saveChatStateAsync(chatID int64, state *ChatState) {
+	state.RLock()
+	doc := ChatStateDoc{
+		ChatID:            chatID,
+		Word:              state.Word,
+		User:              state.User,
+		LeadTimestamp:     state.LeadTimestamp,
+		Leader:            state.Leader,
+		LastHintTimestamp: state.LastHintTimestamp,
+		LastHintTypeSent:  state.LastHintTypeSent,
+	}
+	state.RUnlock()
+
+	go func() {
+		client := repository.DbManager()
+		if client != nil {
+			repository.SaveGameState(client, "ChatStates", chatID, doc)
+		}
+	}()
+}
+
 // ChatState holds the state for a specific chat, including the current word and user explaining it.
 type ChatState struct {
 	sync.RWMutex
@@ -123,13 +156,40 @@ func (cs *ChatState) isLeaderActive(duration time.Duration) bool {
 }
 
 // reset resets the chat state.
-func (cs *ChatState) reset() {
+func (cs *ChatState) reset(chatID int64) {
 	cs.Lock()
-	defer cs.Unlock()
 	cs.Word = ""
 	cs.User = 0
 	cs.LeadTimestamp = time.Time{}
 	cs.Leader = ""
+	cs.Unlock()
+	saveChatStateAsync(chatID, cs)
+}
+
+// loadSavedChatStates loads states from MongoDB into the chatStates map
+func loadSavedChatStates(client *mongo.Client) {
+	var results []ChatStateDoc
+	err := repository.LoadAllGameStates(client, "ChatStates", &results)
+	if err != nil {
+		log.Printf("Failed to load saved chat states: %v", err)
+		return
+	}
+
+	stateMutex.Lock()
+	defer stateMutex.Unlock()
+
+	for _, doc := range results {
+		cs := &ChatState{
+			Word:              doc.Word,
+			User:              doc.User,
+			LeadTimestamp:     doc.LeadTimestamp,
+			Leader:            doc.Leader,
+			LastHintTimestamp: doc.LastHintTimestamp,
+			LastHintTypeSent:  doc.LastHintTypeSent,
+		}
+		chatStates[doc.ChatID] = cs
+	}
+	log.Printf("Loaded %d active Word Guess games from MongoDB", len(results))
 }
 
 // StartBot initializes and starts the bot
@@ -148,6 +208,11 @@ func StartBot(token string) error {
 	if client == nil {
 		return fmt.Errorf("failed to connect to MongoDB")
 	}
+
+	loadSavedChatStates(client)
+	wordlebot.LoadSavedStates(client)
+	scramybot.LoadSavedStates(client)
+
 	if err := wordlebot.LoadWordleWords(); err != nil {
 		log.Printf("failed to load Wordle words: %v", err)
 	}
@@ -456,6 +521,7 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 			chatState.LastHintTimestamp = time.Time{}
 			chatState.LastHintTypeSent = 0
 			chatState.Unlock()
+			saveChatStateAsync(chatID, chatState)
 			return
 		}
 
@@ -484,6 +550,7 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 			chatState.LastHintTimestamp = time.Now()
 			chatState.LastHintTypeSent = 1 - lastHintType
 			chatState.Unlock()
+			saveChatStateAsync(chatID, chatState)
 			return
 		}
 
@@ -491,7 +558,7 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 		if message.Command() == "reveal" {
 			if time.Since(chatState.LeadTimestamp) >= 6*time.Second {
 				view.SendMessage(bot, chatID, fmt.Sprintf("The word was: %s", chatState.Word))
-				chatState.reset()
+				chatState.reset(chatID)
 			} else {
 				sentMsg, err := view.SendMessage(bot, chatID, "Please try to read the hint before revealing the word.")
 				deleteWarningMessage(bot, message, sentMsg, err)
@@ -568,11 +635,11 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 				}()
 				repository.InsertDoc(message.From.ID, message.From.FirstName, chatID, client, "CrocEn")
 			}()
-			chatState.reset()
+			chatState.reset(chatID)
 			word, err := model.GetRandomWord()
 			if err != nil {
 				view.SendMessage(bot, chatID, "Failed to load next word.")
-				chatState.reset()
+				chatState.reset(chatID)
 				return
 			}
 
@@ -583,6 +650,7 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 			chatState.LastHintTimestamp = time.Time{}
 			chatState.LastHintTypeSent = 0
 			chatState.Unlock()
+			saveChatStateAsync(chatID, chatState)
 
 			return
 		}
@@ -735,6 +803,7 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 			chatState.User = 0
 			chatState.Leader = ""
 			chatState.Unlock()
+			saveChatStateAsync(chatID, chatState)
 
 			// THE CHARACTER UPGRADE:
 			sendCharacterAction(bot, chatID, StickerOwlWatching,
@@ -807,6 +876,7 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 		chatState.LastHintTimestamp = time.Now()
 		chatState.LastHintTypeSent = 1 - lastHintType
 		chatState.Unlock()
+			saveChatStateAsync(chatID, chatState)
 	case "reveal":
 		chatState.RLock()
 		word := chatState.Word
@@ -820,7 +890,7 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 			})
 			view.SendMessageWithButtons(bot, message.Chat.ID, fmt.Sprintf("The word was: %s", word), buttons)
 
-			chatState.reset()
+			chatState.reset(chatID)
 		} else {
 			sentMsg, err := view.SendMessage(bot, message.Chat.ID, "Please wait for 10 minutes before revealing the word.")
 			deleteWarningMessage(bot, message, sentMsg, err)
@@ -842,7 +912,7 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 		chatState.RUnlock()
 
 		if user != 0 && service.NormalizeAndCompare(message.Text, word) && message.From.ID != user {
-			chatState.reset()
+			chatState.reset(chatID)
 
 			// THE CHARACTER UPGRADE:
 			victoryText := fmt.Sprintf("🎊 *The forest erupts in cheers!*\n\n🦉 \"Correct. The word was indeed **%s**.\"\n🐊 \"WOW! [%s](tg://user?id=%d) is a genius! Can we play again? Can we?!\"",
@@ -972,11 +1042,13 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		if chatState.User != callback.From.ID && chatState.User != 0 && time.Since(chatState.LeadTimestamp) < 600*time.Second {
 			bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, fmt.Sprintf("%s is already explaining the word. Please wait for your turn, %s.", chatState.Leader, callback.From.UserName)))
 			chatState.Unlock()
+			saveChatStateAsync(chatID, chatState)
 			return
 		}
 		if chatState.User == callback.From.ID {
 			bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, chatState.Word))
 			chatState.Unlock()
+			saveChatStateAsync(chatID, chatState)
 			return
 		}
 		if chatState.User == 0 || (time.Since(chatState.LeadTimestamp) >= 600*time.Second && chatState.User != callback.From.ID) {
@@ -990,6 +1062,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 			word, err := model.GetRandomWord()
 			if err != nil {
 				chatState.Unlock()
+			saveChatStateAsync(chatID, chatState)
 				return
 			}
 			customWordLink := fmt.Sprintf("https://t.me/%s?start=custom_word_%d", bot.Self.UserName, chatID)
@@ -1032,6 +1105,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		chatState.Leader = callback.From.FirstName
 		chatState.LeadTimestamp = time.Now()
 		chatState.Unlock()
+			saveChatStateAsync(chatID, chatState)
 		bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, chatState.Word))
 
 	case "next":
@@ -1039,17 +1113,20 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		if chatState.User != callback.From.ID && chatState.User != 0 {
 			bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, fmt.Sprintf("%s is already explaining the word. %s", chatState.Leader, callback.From.UserName)))
 			chatState.Unlock()
+			saveChatStateAsync(chatID, chatState)
 			return
 		}
 		if chatState.User == 0 {
 			bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, fmt.Sprintf("%s Please click on see word/claim Leadership", callback.From.FirstName)))
 			chatState.Unlock()
+			saveChatStateAsync(chatID, chatState)
 			return
 		}
 		chatState.User = callback.From.ID
 		chatState.Leader = callback.From.FirstName
-		chatState.Unlock()
 		chatState.Word, _ = model.GetRandomWord()
+		chatState.Unlock()
+		saveChatStateAsync(chatID, chatState)
 		bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, chatState.Word))
 
 	case "droplead":
@@ -1057,6 +1134,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		if chatState.User != callback.From.ID {
 			bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, "You are not the current leader, so you cannot drop the lead!"))
 			chatState.Unlock()
+			saveChatStateAsync(chatID, chatState)
 			return
 		}
 		// Delete the callback message when user selects "Changed my mind"
@@ -1066,9 +1144,10 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 			log.Printf("Failed to delete message on droplead: %v", err)
 		}
 		chatState.Unlock()
+			saveChatStateAsync(chatID, chatState)
 		buttons := createSingleButtonKeyboard("🌟 Claim Leadership 🙋", "explain")
 		view.SendMessageWithButtons(bot, callback.Message.Chat.ID, fmt.Sprintf("%s refused to lead -> %s \n", callback.From.FirstName, chatState.Word), buttons)
-		chatState.reset()
+		chatState.reset(chatID)
 
 	case "hint":
 		chatState.RLock()
@@ -1082,7 +1161,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 				word, err := model.GetRandomWord()
 				if err != nil {
 					view.SendMessage(bot, chatID, "Failed to load next word.")
-					chatState.reset()
+					chatState.reset(chatID)
 					return
 				}
 
@@ -1093,6 +1172,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 				chatState.LastHintTimestamp = time.Time{}
 				chatState.LastHintTypeSent = 0
 				chatState.Unlock()
+			saveChatStateAsync(chatID, chatState)
 			} else {
 				buttons := createMultiButtonKeyboard([][]string{
 					{" 🗣️ Explain ", "explain"},
@@ -1139,6 +1219,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		chatState.LastHintTimestamp = time.Now()
 		chatState.LastHintTypeSent = 1 - lastHintType
 		chatState.Unlock()
+			saveChatStateAsync(chatID, chatState)
 
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
 	default:
@@ -1148,9 +1229,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		if service.NormalizeAndCompare(callback.Message.Text, word) {
 			buttons := createSingleButtonKeyboard("🌟 Claim Leadership 🙋", "explain")
 			view.SendMessageWithButtons(bot, callback.Message.Chat.ID, fmt.Sprintf("%s! %s guessed the word correctly.", telegramReactions[0], callback.From.FirstName), buttons)
-			chatState.Lock()
-			chatState.reset()
-			chatState.Unlock()
+			chatState.reset(chatID)
 		}
 	}
 	bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))

--- a/controller/categoryBot/categoryBot.go
+++ b/controller/categoryBot/categoryBot.go
@@ -67,6 +67,65 @@ func replaceWord(original, word string) string {
 	return strings.Join(words, " ")
 }
 
+// CategoryChatStateDoc is the MongoDB-serializable version of ChatState
+type CategoryChatStateDoc struct {
+	ChatID            int64     `bson:"_id"`
+	Word              string    `bson:"word"`
+	User              int       `bson:"user"`
+	LeadTimestamp     time.Time `bson:"lead_timestamp"`
+	Leader            string    `bson:"leader"`
+	LastHintTimestamp time.Time `bson:"last_hint_timestamp"`
+	LastHintTypeSent  int       `bson:"last_hint_type_sent"`
+}
+
+// saveCategoryChatStateAsync asynchronously saves a chat state to MongoDB.
+func saveCategoryChatStateAsync(chatID int64, state *ChatState) {
+	state.RLock()
+	doc := CategoryChatStateDoc{
+		ChatID:            chatID,
+		Word:              state.Word,
+		User:              state.User,
+		LeadTimestamp:     state.LeadTimestamp,
+		Leader:            state.Leader,
+		LastHintTimestamp: state.LastHintTimestamp,
+		LastHintTypeSent:  state.LastHintTypeSent,
+	}
+	state.RUnlock()
+
+	go func() {
+		client := repository.DbManager()
+		if client != nil {
+			repository.SaveGameState(client, "CategoryChatStates", chatID, doc)
+		}
+	}()
+}
+
+// loadSavedCategoryChatStates loads states from MongoDB into the chatStates map
+func loadSavedCategoryChatStates(client *mongo.Client) {
+	var results []CategoryChatStateDoc
+	err := repository.LoadAllGameStates(client, "CategoryChatStates", &results)
+	if err != nil {
+		log.Printf("Failed to load saved category chat states: %v", err)
+		return
+	}
+
+	stateMutex.Lock()
+	defer stateMutex.Unlock()
+
+	for _, doc := range results {
+		cs := &ChatState{
+			Word:              doc.Word,
+			User:              doc.User,
+			LeadTimestamp:     doc.LeadTimestamp,
+			Leader:            doc.Leader,
+			LastHintTimestamp: doc.LastHintTimestamp,
+			LastHintTypeSent:  doc.LastHintTypeSent,
+		}
+		chatStates[doc.ChatID] = cs
+	}
+	log.Printf("Loaded %d active Word Guess games from MongoDB (Category Bot)", len(results))
+}
+
 // ChatState holds the state for a specific chat, including the current word and user explaining it.
 type ChatState struct {
 	sync.RWMutex
@@ -182,17 +241,28 @@ func (cs *ChatState) isLeaderActive(duration time.Duration) bool {
 }
 
 // reset resets the chat state.
-func (cs *ChatState) reset() {
+func (cs *ChatState) reset(chatID int64) {
 	cs.Lock()
-	defer cs.Unlock()
 	cs.Word = ""
 	cs.User = 0
 	cs.LeadTimestamp = time.Time{}
 	cs.Leader = ""
+	cs.Unlock()
+	saveCategoryChatStateAsync(chatID, cs)
 }
 
 // StartBot initializes and starts the bot
 func StartBot(token string) error {
+	// Create a single MongoDB client instance once
+	client := repository.DbManager()
+	if client == nil {
+		return fmt.Errorf("failed to connect to MongoDB")
+	}
+
+	loadSavedCategoryChatStates(client)
+	wordlebot.LoadSavedStates(client)
+	scramybot.LoadSavedStates(client)
+
 	if err := wordlebot.LoadWordleWords(); err != nil {
 		log.Printf("Warning: failed to load Wordle words: %v", err)
 	}
@@ -208,12 +278,6 @@ func StartBot(token string) error {
 
 	bot.Debug = true
 	log.Printf("Authorized on account %s", bot.Self.UserName)
-
-	// Create a single MongoDB client instance once
-	client := repository.DbManager()
-	if client == nil {
-		return fmt.Errorf("failed to connect to MongoDB")
-	}
 
 	u := tgbotapi.NewUpdate(0)
 	u.Timeout = 60
@@ -494,6 +558,7 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 			chatState.LastHintTimestamp = time.Time{}
 			chatState.LastHintTypeSent = 0
 			chatState.Unlock()
+			saveCategoryChatStateAsync(chatID, chatState)
 			return
 		}
 
@@ -570,6 +635,7 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 			chatState.LastHintTimestamp = time.Now()
 			chatState.LastHintTypeSent = 1 - lastHintType
 			chatState.Unlock()
+			saveCategoryChatStateAsync(chatID, chatState)
 			return
 		}
 
@@ -577,7 +643,7 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 		if message.Command() == "reveal" {
 			if time.Since(chatState.LeadTimestamp) >= 6*time.Second {
 				view.SendMessage(bot, chatID, fmt.Sprintf("The word was: %s", chatState.Word))
-				chatState.reset()
+				chatState.reset(chatID)
 			} else {
 				sentMsg, err := view.SendMessage(bot, chatID, "Please try to read the hint before revealing the word.")
 				deleteWarningMessage(bot, message, sentMsg, err)
@@ -651,7 +717,7 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 				repository.InsertDoc(message.From.ID, message.From.FirstName, chatID, client, "CrocEn")
 			}()
 
-			chatState.reset()
+			chatState.reset(chatID)
 			return
 		}
 		aiModeMutex.Lock()
@@ -858,6 +924,7 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 			chatState.User = 0
 			chatState.Leader = ""
 			chatState.Unlock()
+			saveCategoryChatStateAsync(chatID, chatState)
 
 			view.SendSticker(bot, chatID, "CAACAgUAAxkBAAEwCnNnYW-OkgV7Odt9osVwoBSzLC6vsAACMhMAAj45CFdCstMoIYiPfjYE")
 			view.SendMessageWithButtons(bot, message.Chat.ID, "The word is ready! Click 'Explain' to start explaining it.", buttons)
@@ -965,6 +1032,7 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 		chatState.LastHintTimestamp = time.Now()
 		chatState.LastHintTypeSent = 1 - lastHintType
 		chatState.Unlock()
+			saveCategoryChatStateAsync(chatID, chatState)
 	case "reveal":
 		chatState.RLock()
 		word := chatState.Word
@@ -975,7 +1043,7 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 			buttons := createSingleButtonKeyboard(" 🗣️ Explain ", "explain")
 			view.SendMessageWithButtons(bot, message.Chat.ID, fmt.Sprintf("The word was: %s", word), buttons)
 
-			chatState.reset()
+			chatState.reset(chatID)
 		} else {
 			sentMsg, err := view.SendMessage(bot, message.Chat.ID, "Please wait for 10 minutes before revealing the word.")
 			deleteWarningMessage(bot, message, sentMsg, err)
@@ -997,7 +1065,7 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 		chatState.RUnlock()
 
 		if user != 0 && service.NormalizeAndCompare(message.Text, word) && message.From.ID != user {
-			chatState.reset()
+			chatState.reset(chatID)
 			buttons := createSingleButtonKeyboard("🌟 Claim Leadership 🙋", "explain")
 			view.SendMessageWithButtons(bot, message.Chat.ID, fmt.Sprintf("%s! %s guessed the word %s.\n /word", telegramReactions[7], message.From.FirstName, word), buttons)
 			go view.ReactToMessage(bot.Token, chatID, message.MessageID, telegramReactions[rand.Intn(8)+13], true)
@@ -1138,11 +1206,13 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		if chatState.User != callback.From.ID && chatState.User != 0 && time.Since(chatState.LeadTimestamp) < 600*time.Second {
 			bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, fmt.Sprintf("%s is already explaining the word. Please wait for your turn, %s.", chatState.Leader, callback.From.UserName)))
 			chatState.Unlock()
+			saveCategoryChatStateAsync(chatID, chatState)
 			return
 		}
 		if chatState.User == callback.From.ID {
 			bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, chatState.Word))
 			chatState.Unlock()
+			saveCategoryChatStateAsync(chatID, chatState)
 			return
 		}
 		if chatState.User == 0 || (time.Since(chatState.LeadTimestamp) >= 600*time.Second && chatState.User != callback.From.ID) {
@@ -1150,6 +1220,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 			word, err := model.GetRandomWord()
 			if err != nil {
 				chatState.Unlock()
+			saveCategoryChatStateAsync(chatID, chatState)
 				return
 			}
 			buttons := createCategoryBotKeyboard(bot.Self.UserName, chatID)
@@ -1166,6 +1237,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		chatState.Leader = callback.From.FirstName
 		chatState.LeadTimestamp = time.Now()
 		chatState.Unlock()
+			saveCategoryChatStateAsync(chatID, chatState)
 		bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, chatState.Word))
 	case "wordle_start":
 		wordlebot.HandleWordleCommand(bot, chatID, callback.From.FirstName)
@@ -1244,21 +1316,26 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		if chatState.User != callback.From.ID && chatState.User != 0 {
 			bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, fmt.Sprintf("someone is already explaining the word. %s", callback.From.UserName)))
 			chatState.Unlock()
+			saveCategoryChatStateAsync(chatID, chatState)
 			return
 		}
 		if chatState.User == 0 {
 			bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, fmt.Sprintf("%s Please click on see word/claim Leadership", callback.From.FirstName)))
 			chatState.Unlock()
+			saveCategoryChatStateAsync(chatID, chatState)
 			return
 		}
 		chatState.User = callback.From.ID
-		chatState.Unlock()
 		word, err := model.GetRandomAnimal()
 		if err != nil {
 			bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, "Failed to get an animal word. Please try again later."))
+			chatState.Unlock()
+			saveCategoryChatStateAsync(chatID, chatState)
 			return
 		}
 		chatState.Word = word
+		chatState.Unlock()
+		saveCategoryChatStateAsync(chatID, chatState)
 		bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, chatState.Word))
 
 	case "next":
@@ -1266,17 +1343,20 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		if chatState.User != callback.From.ID && chatState.User != 0 {
 			bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, fmt.Sprintf("%s is already explaining the word. %s", chatState.Leader, callback.From.UserName)))
 			chatState.Unlock()
+			saveCategoryChatStateAsync(chatID, chatState)
 			return
 		}
 		if chatState.User == 0 {
 			bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, fmt.Sprintf("%s Please click on see word/claim Leadership", callback.From.FirstName)))
 			chatState.Unlock()
+			saveCategoryChatStateAsync(chatID, chatState)
 			return
 		}
 		chatState.User = callback.From.ID
 		chatState.Leader = callback.From.FirstName
-		chatState.Unlock()
 		chatState.Word, _ = model.GetRandomWord()
+		chatState.Unlock()
+		saveCategoryChatStateAsync(chatID, chatState)
 		bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, chatState.Word))
 
 	case "flower":
@@ -1284,16 +1364,19 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		if chatState.User != callback.From.ID && chatState.User != 0 {
 			bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, fmt.Sprintf("someone is already explaining the word. %s", callback.From.UserName)))
 			chatState.Unlock()
+			saveCategoryChatStateAsync(chatID, chatState)
 			return
 		}
 		if chatState.User == 0 {
 			bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, fmt.Sprintf("%s Please click on see word/claim Leadership", callback.From.FirstName)))
 			chatState.Unlock()
+			saveCategoryChatStateAsync(chatID, chatState)
 			return
 		}
 		chatState.User = callback.From.ID
-		chatState.Unlock()
 		chatState.Word, _ = model.GetRandomFlower()
+		chatState.Unlock()
+		saveCategoryChatStateAsync(chatID, chatState)
 		bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, chatState.Word))
 
 	case "car":
@@ -1301,16 +1384,19 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		if chatState.User != callback.From.ID && chatState.User != 0 {
 			bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, fmt.Sprintf("someone is already explaining the word. %s", callback.From.UserName)))
 			chatState.Unlock()
+			saveCategoryChatStateAsync(chatID, chatState)
 			return
 		}
 		if chatState.User == 0 {
 			bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, fmt.Sprintf("%s Please click on see word/claim Leadership", callback.From.FirstName)))
 			chatState.Unlock()
+			saveCategoryChatStateAsync(chatID, chatState)
 			return
 		}
 		chatState.User = callback.From.ID
-		chatState.Unlock()
 		chatState.Word, _ = model.GetRandomCar()
+		chatState.Unlock()
+		saveCategoryChatStateAsync(chatID, chatState)
 		bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, chatState.Word))
 
 	case "droplead":
@@ -1318,6 +1404,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		if chatState.User != callback.From.ID {
 			bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, "You are not the current leader, so you cannot drop the lead!"))
 			chatState.Unlock()
+			saveCategoryChatStateAsync(chatID, chatState)
 			return
 		}
 		// Delete the callback message when user selects "Changed my mind"
@@ -1327,9 +1414,10 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 			log.Printf("Failed to delete message on droplead: %v", err)
 		}
 		chatState.Unlock()
+			saveCategoryChatStateAsync(chatID, chatState)
 		buttons := createSingleButtonKeyboard("🌟 Claim Leadership 🙋", "explain")
 		view.SendMessageWithButtons(bot, callback.Message.Chat.ID, fmt.Sprintf("%s refused to lead -> %s \n", callback.From.FirstName, chatState.Word), buttons)
-		chatState.reset()
+		chatState.reset(chatID)
 
 	case "hint":
 		chatState.RLock()
@@ -1379,6 +1467,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		chatState.LastHintTimestamp = time.Now()
 		chatState.LastHintTypeSent = 1 - lastHintType
 		chatState.Unlock()
+			saveCategoryChatStateAsync(chatID, chatState)
 
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
 	default:
@@ -1388,9 +1477,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		if service.NormalizeAndCompare(callback.Message.Text, word) {
 			buttons := createSingleButtonKeyboard("🌟 Claim Leadership 🙋", "explain")
 			view.SendMessageWithButtons(bot, callback.Message.Chat.ID, fmt.Sprintf("%s! %s guessed the word correctly.", telegramReactions[0], callback.From.FirstName), buttons)
-			chatState.Lock()
-			chatState.reset()
-			chatState.Unlock()
+			chatState.reset(chatID)
 		}
 	}
 	bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))

--- a/controller/scramybot/scramybot.go
+++ b/controller/scramybot/scramybot.go
@@ -18,6 +18,108 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
+// ScramyStateDoc is the MongoDB-serializable version of ScramyState
+type ScramyStateDoc struct {
+	ChatID         int64            `bson:"_id"`
+	Active         bool             `bson:"active"`
+	Letters        string           `bson:"letters"`
+	FoundWords     []string         `bson:"found_words"`
+	UserWords      map[string][]string `bson:"user_words"`
+	UserScores     map[string]int   `bson:"user_scores"`
+	UserNames      map[string]string `bson:"user_names"`
+	MaxWords       int              `bson:"max_words"`
+	PendingNewGame bool             `bson:"pending_new_game"`
+}
+
+// saveScramyStateAsync asynchronously saves the Scramy state to MongoDB
+func saveScramyStateAsync(chatID int64, state *ScramyState) {
+	state.RLock()
+
+	// Convert int keys to string keys for MongoDB BSON compatibility
+	userWordsStr := make(map[string][]string)
+	for k, v := range state.UserWords {
+		userWordsStr[fmt.Sprintf("%d", k)] = v
+	}
+
+	userScoresStr := make(map[string]int)
+	for k, v := range state.UserScores {
+		userScoresStr[fmt.Sprintf("%d", k)] = v
+	}
+
+	userNamesStr := make(map[string]string)
+	for k, v := range state.UserNames {
+		userNamesStr[fmt.Sprintf("%d", k)] = v
+	}
+
+	doc := ScramyStateDoc{
+		ChatID:         chatID,
+		Active:         state.Active,
+		Letters:        state.Letters,
+		FoundWords:     state.FoundWords,
+		UserWords:      userWordsStr,
+		UserScores:     userScoresStr,
+		UserNames:      userNamesStr,
+		MaxWords:       state.MaxWords,
+		PendingNewGame: state.PendingNewGame,
+	}
+	state.RUnlock()
+
+	go func() {
+		client := repository.DbManager()
+		if client != nil {
+			repository.SaveGameState(client, "ScramyStates", chatID, doc)
+		}
+	}()
+}
+
+// LoadSavedStates loads the persisted Scramy states from MongoDB into the memory map
+func LoadSavedStates(client *mongo.Client) {
+	var results []ScramyStateDoc
+	err := repository.LoadAllGameStates(client, "ScramyStates", &results)
+	if err != nil {
+		log.Printf("Failed to load saved Scramy states: %v", err)
+		return
+	}
+
+	scramyMutex.Lock()
+	defer scramyMutex.Unlock()
+
+	for _, doc := range results {
+		ss := &ScramyState{
+			Active:         doc.Active,
+			Letters:        doc.Letters,
+			MaxWords:       doc.MaxWords,
+			PendingNewGame: doc.PendingNewGame,
+			FoundWords:     doc.FoundWords,
+			UserWords:      make(map[int][]string),
+			UserScores:     make(map[int]int),
+			UserNames:      make(map[int]string),
+			CancelChan:     make(chan bool, 1),
+		}
+
+		for kStr, v := range doc.UserWords {
+			var k int
+			fmt.Sscanf(kStr, "%d", &k)
+			ss.UserWords[k] = v
+		}
+
+		for kStr, v := range doc.UserScores {
+			var k int
+			fmt.Sscanf(kStr, "%d", &k)
+			ss.UserScores[k] = v
+		}
+
+		for kStr, v := range doc.UserNames {
+			var k int
+			fmt.Sscanf(kStr, "%d", &k)
+			ss.UserNames[k] = v
+		}
+
+		scramyStates[doc.ChatID] = ss
+	}
+	log.Printf("Loaded %d active Scramy games from MongoDB", len(results))
+}
+
 // ScramyState holds the state for a Scramy game in a specific chat.
 type ScramyState struct {
 	sync.RWMutex
@@ -224,11 +326,13 @@ func HandleScramyCommand(bot *tgbotapi.BotAPI, chatID int64, username string) {
 	if ss.Active {
 		if ss.PendingNewGame {
 			ss.Unlock()
+			saveScramyStateAsync(chatID, ss)
 			return
 		}
 		ss.PendingNewGame = true
 		ss.CancelChan = make(chan bool, 1)
 		ss.Unlock()
+			saveScramyStateAsync(chatID, ss)
 
 		markup := tgbotapi.NewInlineKeyboardMarkup(
 			tgbotapi.NewInlineKeyboardRow(
@@ -248,6 +352,7 @@ func HandleScramyCommand(bot *tgbotapi.BotAPI, chatID int64, username string) {
 				ss.Lock()
 				if !ss.PendingNewGame {
 					ss.Unlock()
+			saveScramyStateAsync(chatID, ss)
 					return
 				}
 				ss.PendingNewGame = false
@@ -258,6 +363,7 @@ func HandleScramyCommand(bot *tgbotapi.BotAPI, chatID int64, username string) {
 				ss.UserScores = make(map[int]int)
 				ss.UserNames = make(map[int]string)
 				ss.Unlock()
+			saveScramyStateAsync(chatID, ss)
 
 				if err == nil {
 					deleteMsg := tgbotapi.NewDeleteMessage(chatID, sentMsg.MessageID)
@@ -283,6 +389,7 @@ func HandleScramyCommand(bot *tgbotapi.BotAPI, chatID int64, username string) {
 	ss.UserScores = make(map[int]int)
 	ss.UserNames = make(map[int]string)
 	ss.Unlock()
+			saveScramyStateAsync(chatID, ss)
 
 	msg := fmt.Sprintf("📝 *WORD SCRAMBLE*\n\n🦴 Make words using these letters\n\n%s\n\n🔎 Words with 4 or more letters are accepted. Longer words give more points!\n\nTotal: 0/10", ss.Letters)
 	view.SendMessage(bot, chatID, msg)
@@ -292,7 +399,10 @@ func HandleScramyCommand(bot *tgbotapi.BotAPI, chatID int64, username string) {
 func CancelPendingGame(bot *tgbotapi.BotAPI, chatID int64, username string) bool {
 	ss := GetOrCreateScramyState(chatID)
 	ss.Lock()
-	defer ss.Unlock()
+	defer func() {
+		ss.Unlock()
+		saveScramyStateAsync(chatID, ss)
+	}()
 
 	if ss.PendingNewGame {
 		ss.PendingNewGame = false
@@ -335,7 +445,10 @@ func capitalizeWord(word string) string {
 func HandleGuess(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mongo.Client, chatID int64, text string) {
 	ss := GetOrCreateScramyState(chatID)
 	ss.Lock()
-	defer ss.Unlock()
+	defer func() {
+		ss.Unlock()
+		saveScramyStateAsync(chatID, ss)
+	}()
 
 	if !ss.Active {
 		return

--- a/controller/wordlebot/wordlebot.go
+++ b/controller/wordlebot/wordlebot.go
@@ -16,6 +16,66 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
+// WordleStateDoc is the MongoDB-serializable version of WordleState
+type WordleStateDoc struct {
+	ChatID         int64    `bson:"_id"`
+	Active         bool     `bson:"active"`
+	Word           string   `bson:"word"`
+	Guesses        []string `bson:"guesses"`
+	Attempts       int      `bson:"attempts"`
+	MaxAttempts    int      `bson:"max_attempts"`
+	PendingNewGame bool     `bson:"pending_new_game"`
+}
+
+// saveWordleStateAsync asynchronously saves the Wordle state to MongoDB
+func saveWordleStateAsync(chatID int64, state *WordleState) {
+	state.RLock()
+	doc := WordleStateDoc{
+		ChatID:         chatID,
+		Active:         state.Active,
+		Word:           state.Word,
+		Guesses:        state.Guesses,
+		Attempts:       state.Attempts,
+		MaxAttempts:    state.MaxAttempts,
+		PendingNewGame: state.PendingNewGame,
+	}
+	state.RUnlock()
+
+	go func() {
+		client := repository.DbManager()
+		if client != nil {
+			repository.SaveGameState(client, "WordleStates", chatID, doc)
+		}
+	}()
+}
+
+// LoadSavedStates loads the persisted Wordle states from MongoDB into the memory map
+func LoadSavedStates(client *mongo.Client) {
+	var results []WordleStateDoc
+	err := repository.LoadAllGameStates(client, "WordleStates", &results)
+	if err != nil {
+		log.Printf("Failed to load saved Wordle states: %v", err)
+		return
+	}
+
+	wordleMutex.Lock()
+	defer wordleMutex.Unlock()
+
+	for _, doc := range results {
+		ws := &WordleState{
+			Active:         doc.Active,
+			Word:           doc.Word,
+			Guesses:        doc.Guesses,
+			Attempts:       doc.Attempts,
+			MaxAttempts:    doc.MaxAttempts,
+			PendingNewGame: doc.PendingNewGame,
+			CancelChan:     make(chan bool, 1),
+		}
+		wordleStates[doc.ChatID] = ws
+	}
+	log.Printf("Loaded %d active Wordle games from MongoDB", len(results))
+}
+
 // WordleState holds the state for a Wordle game in a specific chat.
 type WordleState struct {
 	sync.RWMutex
@@ -224,11 +284,13 @@ func HandleWordleCommand(bot *tgbotapi.BotAPI, chatID int64, username string) {
 	if ws.Active {
 		if ws.PendingNewGame {
 			ws.Unlock()
+			saveWordleStateAsync(chatID, ws)
 			return // Already a pending request
 		}
 		ws.PendingNewGame = true
 		ws.CancelChan = make(chan bool, 1)
 		ws.Unlock()
+			saveWordleStateAsync(chatID, ws)
 
 		markup := tgbotapi.NewInlineKeyboardMarkup(
 			tgbotapi.NewInlineKeyboardRow(
@@ -249,6 +311,7 @@ func HandleWordleCommand(bot *tgbotapi.BotAPI, chatID int64, username string) {
 				if !ws.PendingNewGame {
 					// It was cancelled
 					ws.Unlock()
+			saveWordleStateAsync(chatID, ws)
 					return
 				}
 				ws.PendingNewGame = false
@@ -257,6 +320,7 @@ func HandleWordleCommand(bot *tgbotapi.BotAPI, chatID int64, username string) {
 				ws.Guesses = make([]string, 0)
 				ws.Attempts = 0
 				ws.Unlock()
+			saveWordleStateAsync(chatID, ws)
 
 				if err == nil {
 					deleteMsg := tgbotapi.NewDeleteMessage(chatID, sentMsg.MessageID)
@@ -281,6 +345,7 @@ func HandleWordleCommand(bot *tgbotapi.BotAPI, chatID int64, username string) {
 	ws.Guesses = make([]string, 0)
 	ws.Attempts = 0
 	ws.Unlock()
+			saveWordleStateAsync(chatID, ws)
 
 	msg := fmt.Sprintf("🐊 🖼 *Wordle started!* ✨\n\n• The word consists of 5 letters.\n• You have %d attempts.\n\n💡 Hints:\n🟩 Correct letter in the right spot\n🟨 Correct letter but in the wrong spot\n🟥 Letter is not in the word\n\nSend a 5-letter word to guess.", ws.MaxAttempts)
 	view.SendMessage(bot, chatID, msg)
@@ -290,7 +355,10 @@ func HandleWordleCommand(bot *tgbotapi.BotAPI, chatID int64, username string) {
 func CancelPendingGame(bot *tgbotapi.BotAPI, chatID int64, username string) bool {
 	ws := GetOrCreateWordleState(chatID)
 	ws.Lock()
-	defer ws.Unlock()
+	defer func() {
+		ws.Unlock()
+		saveWordleStateAsync(chatID, ws)
+	}()
 
 	if ws.PendingNewGame {
 		ws.PendingNewGame = false
@@ -308,7 +376,10 @@ func CancelPendingGame(bot *tgbotapi.BotAPI, chatID int64, username string) bool
 func HandleGuess(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mongo.Client, chatID int64, text string) {
 	ws := GetOrCreateWordleState(chatID)
 	ws.Lock()
-	defer ws.Unlock()
+	defer func() {
+		ws.Unlock()
+		saveWordleStateAsync(chatID, ws)
+	}()
 
 	if !ws.Active {
 		return

--- a/plan.md
+++ b/plan.md
@@ -1,16 +1,40 @@
-1. **Add `EditMessageTextWithStyledButtons` to `view/custom_http.go`**
-   - Create a new struct `EditMessageRequest` with `ChatID`, `MessageID`, `Text`, `ParseMode`, and `ReplyMarkup`.
-   - Implement `EditMessageTextWithStyledButtons` similarly to `SendMessageWithStyledButtons` but targeting the `/editMessageText` Telegram API endpoint.
-
-2. **Update `handleCallbackQuery` in `controller/bot.go`**
-   - For callback data cases `statsglobal_*` and `statsgroup_*`, replace `view.SendMessageWithStyledButtons` with `view.EditMessageTextWithStyledButtons`.
-   - Pass `callback.Message.MessageID` to the new function.
-
-3. **Update `handleCallbackQuery` in `controller/categoryBot/categoryBot.go`**
-   - Apply the same changes as above for consistency across bot controllers.
-
-4. **Run Pre-Commit Checks**
-   - Execute all checks to ensure proper testing, verification, review, and reflection are done.
-
-5. **Commit and Submit**
-   - Submit the changes using the `submit` tool.
+1. **Add `SaveGameState` to `repository/dbManager.go`:**
+   - In `repository/dbManager.go`, add `SaveGameState(client *mongo.Client, collectionName string, chatID int64, state interface{})`. This function will use `UpdateOne` with `$set` and `upsert=true` to save game state to a collection.
+2. **Verify `SaveGameState` addition:**
+   - Read `repository/dbManager.go` to ensure `SaveGameState` was added correctly.
+3. **Add `LoadAllGameStates` to `repository/dbManager.go`:**
+   - In `repository/dbManager.go`, add `LoadAllGameStates(client *mongo.Client, collectionName string) ([]bson.M, error)` to retrieve all states from the specified collection.
+4. **Verify `LoadAllGameStates` addition:**
+   - Read `repository/dbManager.go` to ensure `LoadAllGameStates` was added correctly.
+5. **Update Word Guess (Croc) State Management in `bot.go`:**
+   - In `controller/bot.go`, add a structure `ChatStateDoc` suitable for MongoDB (without mutexes).
+   - Create `saveChatStateAsync(chatID int64, state *ChatState)`. It gets a read lock, copies data to `ChatStateDoc`, and calls `repository.SaveGameState` in a goroutine (`collection: "ChatStates"`).
+   - Add calls to `saveChatStateAsync` whenever the state changes (e.g., word set, user changed, reset).
+   - In `StartBot`, load existing states from the `"ChatStates"` collection and populate the `chatStates` map.
+6. **Verify `bot.go` edits:**
+   - Run `go build -v ./...` and use `read_file` to confirm changes in `bot.go` are correct and syntactically sound.
+7. **Update Word Guess State Management in `categoryBot.go`:**
+   - In `controller/categoryBot/categoryBot.go`, define `CategoryChatStateDoc` and create `saveCategoryChatStateAsync(chatID int64, state *ChatState)` using collection `"CategoryChatStates"`.
+   - Call it when state updates, and load from it in `StartBot`.
+8. **Verify `categoryBot.go` edits:**
+   - Run `go build -v ./...` and check changes.
+9. **Update Wordle Game State Management:**
+   - In `controller/wordlebot/wordlebot.go`, add `WordleStateDoc` and `saveWordleStateAsync` (`collection: "WordleStates"`).
+   - Call on game start, guess, cancel, and end.
+   - Add an init function `LoadSavedStates(client *mongo.Client)` to load states from DB.
+10. **Verify `wordlebot.go` edits:**
+   - Run `go build -v ./...` and verify changes.
+11. **Update Scramy Game State Management:**
+   - In `controller/scramybot/scramybot.go`, add `ScramyStateDoc` and `saveScramyStateAsync` (`collection: "ScramyStates"`).
+   - Ignore Channels (`CancelChan`) and Mutexes when extracting state. Save on words found, score updates, game start/cancel.
+   - Add `LoadSavedStates(client *mongo.Client)` to populate maps.
+12. **Verify `scramybot.go` edits:**
+   - Run `go build -v ./...` and verify changes.
+13. **Update bot initializations:**
+   - Call `wordlebot.LoadSavedStates(client)` and `scramybot.LoadSavedStates(client)` in `controller/bot.go` and `controller/categoryBot/categoryBot.go` inside `StartBot`.
+14. **Verify codebase compiles and test:**
+   - Run `go build -v ./...` and `go test ./...` to verify everything works and passes tests.
+15. **Complete pre-commit steps:**
+   - Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+16. **Submit:**
+   - Commit the change with the message "feat: Persist game states in MongoDB to survive restarts"

--- a/repository/dbManager.go
+++ b/repository/dbManager.go
@@ -265,6 +265,40 @@ func InsertUserInfo(userInfo model.UserInfo, client *mongo.Client) {
 	commentCollection.InsertOne(context.TODO(), userInfo)
 }
 
+// SaveGameState saves a game state to the database asynchronously or synchronously.
+func SaveGameState(client *mongo.Client, collectionName string, chatID int64, state interface{}) error {
+	if client == nil {
+		return fmt.Errorf("MongoDB client is nil")
+	}
+
+	collection := client.Database("Telegram").Collection(collectionName)
+	filter := bson.M{"_id": chatID}
+	update := bson.M{"$set": state}
+	opts := options.Update().SetUpsert(true)
+
+	_, err := collection.UpdateOne(context.TODO(), filter, update, opts)
+	if err != nil {
+		log.Printf("Error saving game state for chat %d in %s: %v", chatID, collectionName, err)
+	}
+	return err
+}
+
+// LoadAllGameStates retrieves all game states from the specified collection into the provided target slice pointer.
+func LoadAllGameStates(client *mongo.Client, collectionName string, target interface{}) error {
+	if client == nil {
+		return fmt.Errorf("MongoDB client is nil")
+	}
+
+	collection := client.Database("Telegram").Collection(collectionName)
+	cursor, err := collection.Find(context.TODO(), bson.M{})
+	if err != nil {
+		return err
+	}
+	defer cursor.Close(context.TODO())
+
+	return cursor.All(context.TODO(), target)
+}
+
 // GetUserStatsByID returns the count and name for a specific user ID from the given collection
 func GetUserStatsByID(client *mongo.Client, collection string, userID int) (map[string]interface{}, error) {
 	database := client.Database("Telegram")


### PR DESCRIPTION
Currently, if the telegram bot crashes or is restarted, all ongoing Word Guess, Wordle, and Scramy games are completely lost as their progress only lives in RAM. 

This PR modifies the game logic to write game states asynchronously to MongoDB (`ChatStates`, `CategoryChatStates`, `WordleStates`, `ScramyStates`) using a fire-and-forget goroutine pattern to eliminate blocking overhead. Upon application startup, these collections are loaded directly into memory so users can seamlessly resume their games.

---
*PR created automatically by Jules for task [14982590281719650561](https://jules.google.com/task/14982590281719650561) started by @MUSTAFA-A-KHAN*