### PR TITLE
feat: change wordle incorrect letter color to red

### DIFF
--- a/controller/wordlebot/image_generator/generator.go
+++ b/controller/wordlebot/image_generator/generator.go
@@ -41,7 +41,7 @@ func GenerateWordleImage(guesses []string, targetWord string) ([]byte, error) {
 	emptyCellColor := color.RGBA{58, 58, 60, 255}
 	greenColor := color.RGBA{83, 141, 78, 255}
 	yellowColor := color.RGBA{181, 159, 59, 255}
-	grayColor := color.RGBA{58, 58, 60, 255}
+	redColor := color.RGBA{220, 53, 69, 255}
 	textColor := color.RGBA{255, 255, 255, 255}
 
 	// Fill background
@@ -105,7 +105,7 @@ func GenerateWordleImage(guesses []string, targetWord string) ([]byte, error) {
 				}
 
 				if !foundYellow {
-					colors[c] = grayColor
+					colors[c] = redColor
 				}
 			}
 		}


### PR DESCRIPTION
Updated the `image_generator` logic to use a red color (`#dc3545`) instead of the previous gray color for letters that are entirely incorrect in the generated Wordle grid image.