### PR TITLE
🔨 Forge: Improve emoji shop UX by opening inventory after purchase

### DIFF
--- a/.Jules/forge.md
+++ b/.Jules/forge.md
@@ -1,0 +1,10 @@
+2024-06-06 - Prevent Chat Feed Spam After Shop Purchases
+
+Learning: When building Telegram Bot conversational interfaces, it's a better user experience to edit an existing message with updated content (like showing an inventory screen after a purchase) instead of sending entirely new messages, which pushes previous buttons up and clutters the chat history.
+
+Action: Always look for opportunities to replace  or similar new-message functions with in-place edits (e.g.,  which edits the message) when handling callbacks within a single, continuous user workflow.
+2024-06-06 - Prevent Chat Feed Spam After Shop Purchases
+
+Learning: When building Telegram Bot conversational interfaces, it's a better user experience to edit an existing message with updated content (like showing an inventory screen after a purchase) instead of sending entirely new messages, which pushes previous buttons up and clutters the chat history.
+
+Action: Always look for opportunities to replace 'showShop' or similar new-message functions with in-place edits (e.g., 'showInventory' which edits the message) when handling callbacks within a single, continuous user workflow.

--- a/controller/categoryBot/shopCallback.go
+++ b/controller/categoryBot/shopCallback.go
@@ -157,8 +157,8 @@ func handleBuyEmoji(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery, clie
 
 	bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, fmt.Sprintf("Successfully bought %s for %d points!", emoji, price)))
 
-	// Refresh shop view to potentially show new points or just state
-	showShop(bot, callback.Message.Chat.ID)
+	// Show inventory so the user can immediately equip their new emoji
+	showInventory(bot, callback, client)
 }
 
 func handleEquipEmoji(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery, client *mongo.Client, emoji string) {

--- a/controller/shopCallback.go
+++ b/controller/shopCallback.go
@@ -157,8 +157,8 @@ func handleBuyEmoji(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery, clie
 
 	bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, fmt.Sprintf("Successfully bought %s for %d points!", emoji, price)))
 
-	// Refresh shop view to potentially show new points or just state
-	showShop(bot, callback.Message.Chat.ID)
+	// Show inventory so the user can immediately equip their new emoji
+	showInventory(bot, callback, client)
 }
 
 func handleEquipEmoji(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery, client *mongo.Client, emoji string) {


### PR DESCRIPTION
🔨 Forge: Improve emoji shop UX by opening inventory after purchase

Problem
When users purchased an emoji from the shop, the bot would send a completely new message with the shop UI to the chat feed. This spammed the chat history and orphaned the old buttons, making it frustrating to immediately equip the newly purchased item.

Solution
Replaced the call to `showShop(bot, chatID)` with `showInventory(bot, callback, client)` in both `controller/shopCallback.go` and `controller/categoryBot/shopCallback.go`.

Impact
Users are now seamlessly transitioned to their inventory via an in-place message edit immediately after purchasing an emoji. This prevents chat spam and allows them to equip their new item instantly with a single tap, significantly improving the purchasing workflow.

Alternatives Considered
- Adding a "Go to Inventory" button to the success alert (Not supported by native Telegram alerts).
- Doing nothing (Rejected: the chat feed spam was a noticeable UX flaw).

Validation
- Build results: Passed (`go build -v ./...`)
- Test results: Passed (`go test ./...`)
- Manual verification: The logic directly routes the user to the `showInventory` function which correctly leverages `NewEditMessageText` to avoid new messages.

---
*PR created automatically by Jules for task [16572218363923887609](https://jules.google.com/task/16572218363923887609) started by @MUSTAFA-A-KHAN*