### PR TITLE
feat: show meaning of word on Wordle completion

### DIFF
--- a/controller/wordlebot/wordlebot.go
+++ b/controller/wordlebot/wordlebot.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/model"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/repository"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/view"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/wordlebot/image_generator"
@@ -469,12 +470,22 @@ func HandleGuess(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mongo.
 		)
 
 		if isImage {
-			msg := fmt.Sprintf("🟩 🟩 🟩 🟩 🟩  %s   [+%d💎]\n🎉 [%s](tg://user?id=%d) guessed it in %d attempts!",
-				strings.ToUpper(ws.Word), points, message.From.FirstName, message.From.ID, ws.Attempts)
+			meaning := model.GetWordMeaning(ws.Word)
+			if meaning != "" {
+				meaning = "\n\n```Meaning\n" + meaning + "\n```"
+			}
+
+			msg := fmt.Sprintf("🟩 🟩 🟩 🟩 🟩  %s   [+%d💎]\n🎉 [%s](tg://user?id=%d) guessed it in %d attempts!%s",
+				strings.ToUpper(ws.Word), points, message.From.FirstName, message.From.ID, ws.Attempts, meaning)
 			view.ReplyToMessageWithPhotoAndButtons(bot, message.MessageID, chatID, imgData, msg, buttons)
 		} else {
-			msg := fmt.Sprintf("%s\n\n🟩 🟩 🟩 🟩 🟩  %s   [+%d💎]\n🎉 [%s](tg://user?id=%d) guessed it in %d attempts!",
-				board, strings.ToUpper(ws.Word), points, message.From.FirstName, message.From.ID, ws.Attempts)
+			meaning := model.GetWordMeaning(ws.Word)
+			if meaning != "" {
+				meaning = "\n\n```Meaning\n" + meaning + "\n```"
+			}
+
+			msg := fmt.Sprintf("%s\n\n🟩 🟩 🟩 🟩 🟩  %s   [+%d💎]\n🎉 [%s](tg://user?id=%d) guessed it in %d attempts!%s",
+				board, strings.ToUpper(ws.Word), points, message.From.FirstName, message.From.ID, ws.Attempts, meaning)
 			view.ReplyToMessageWithButtons(bot, message.MessageID, chatID, msg, buttons)
 		}
 
@@ -490,10 +501,20 @@ func HandleGuess(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mongo.
 		)
 
 		if isImage {
-			msg := fmt.Sprintf("❌ Out of attempts! The word was %s.", strings.ToUpper(ws.Word))
+			meaning := model.GetWordMeaning(ws.Word)
+			if meaning != "" {
+				meaning = "\n\n```Meaning\n" + meaning + "\n```"
+			}
+
+			msg := fmt.Sprintf("❌ Out of attempts! The word was %s.%s", strings.ToUpper(ws.Word), meaning)
 			view.ReplyToMessageWithPhotoAndButtons(bot, message.MessageID, chatID, imgData, msg, buttons)
 		} else {
-			msg := fmt.Sprintf("%s\n\n❌ Out of attempts! The word was %s.", board, strings.ToUpper(ws.Word))
+			meaning := model.GetWordMeaning(ws.Word)
+			if meaning != "" {
+				meaning = "\n\n```Meaning\n" + meaning + "\n```"
+			}
+
+			msg := fmt.Sprintf("%s\n\n❌ Out of attempts! The word was %s.%s", board, strings.ToUpper(ws.Word), meaning)
 			view.ReplyToMessageWithButtons(bot, message.MessageID, chatID, msg, buttons)
 		}
 	} else {

--- a/model/anime.go
+++ b/model/anime.go
@@ -204,3 +204,29 @@ func GenerateAuroraHint(word string) string {
 
 	return strings.Join(result, " + ")
 }
+
+
+// GetWordMeaning fetches the meaning of a word from the cache or dictionary API.
+func GetWordMeaning(word string) string {
+	if len(word) == 0 {
+		return ""
+	}
+
+	meaningCache.RLock()
+	cachedMeaning, found := meaningCache.m[word]
+	meaningCache.RUnlock()
+	if found {
+		return strings.ReplaceAll(cachedMeaning, word, "_")
+	}
+
+	meaning, err := fetchMeaningFromAPI(word)
+	if err != nil {
+		return ""
+	}
+
+	meaningCache.Lock()
+	meaningCache.m[word] = meaning
+	meaningCache.Unlock()
+
+	return strings.ReplaceAll(meaning, word, "_")
+}


### PR DESCRIPTION
Adds the dictionary definition of the Wordle target word to the final message when a game ends (either won or lost). The definition is fetched using a thread-safe caching system on top of an external dictionary API. The word itself is obscured in the definition text using underscores. The meaning is formatted as a Markdown block at the end of the message.

---
*PR created automatically by Jules for task [4845557779225834742](https://jules.google.com/task/4845557779225834742) started by @MUSTAFA-A-KHAN*