### PR TITLE
🎨 Palette: Add Back buttons to settings sub-menus

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,5 @@
+## 2024-05-18 - Added Back Buttons to Sub-menus
+
+**Learning:** When users launch sub-menus from a main settings menu, failing to provide a back button leads to a frustrating experience where they must dismiss the prompt and re-open the settings menu from scratch.
+
+**Action:** Ensure all multi-level inline keyboard menus have a "🔙 Back" button to smoothly return to the previous level without abandoning the menu structure entirely.

--- a/controller/bot.go
+++ b/controller/bot.go
@@ -1008,19 +1008,6 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		}
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
 		return
-	case "settings_main":
-		buttons := tgbotapi.NewInlineKeyboardMarkup(
-			tgbotapi.NewInlineKeyboardRow(
-				tgbotapi.NewInlineKeyboardButtonData("Wordle View 🖼️", "setting_wordle_view"),
-				tgbotapi.NewInlineKeyboardButtonData("Scramy Letters 🔠", "setting_scramy_letters"),
-			),
-		)
-		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ **Settings**\nChoose a setting to configure:")
-		editMsg.ReplyMarkup = &buttons
-		editMsg.ParseMode = tgbotapi.ModeMarkdown
-		bot.Send(editMsg)
-		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
-		return
 	case "mystats_main":
 		buttons := tgbotapi.NewInlineKeyboardMarkup(
 			tgbotapi.NewInlineKeyboardRow(
@@ -1055,13 +1042,11 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 	case "setting_scramy_letters_new":
 		buttons := tgbotapi.NewInlineKeyboardMarkup(
 			tgbotapi.NewInlineKeyboardRow(
-				tgbotapi.NewInlineKeyboardButtonData("Squared 🔠", "set_scramy_squared"),
-				tgbotapi.NewInlineKeyboardButtonData("Normal abc", "set_scramy_normal"),
+				tgbotapi.NewInlineKeyboardButtonData("Squared 🔠", "set_scramy_squared_new"),
+				tgbotapi.NewInlineKeyboardButtonData("Normal abc", "set_scramy_normal_new"),
 			),
 		)
-		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ **Scramy Letters Setting**\nChoose the letter style for Scramy:")
-		editMsg.ReplyMarkup = &buttons
-		editMsg.ParseMode = tgbotapi.ModeMarkdown
+		editMsg := tgbotapi.NewEditMessageReplyMarkup(chatID, callback.Message.MessageID, buttons)
 		bot.Send(editMsg)
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
 		return
@@ -1124,13 +1109,11 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 	case "setting_wordle_view_new":
 		buttons := tgbotapi.NewInlineKeyboardMarkup(
 			tgbotapi.NewInlineKeyboardRow(
-				tgbotapi.NewInlineKeyboardButtonData("Text View 📝", "set_wordle_view_text"),
-				tgbotapi.NewInlineKeyboardButtonData("Image View 🖼️", "set_wordle_view_image"),
+				tgbotapi.NewInlineKeyboardButtonData("Text View 📝", "set_wordle_view_text_new"),
+				tgbotapi.NewInlineKeyboardButtonData("Image View 🖼️", "set_wordle_view_image_new"),
 			),
 		)
-		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ **Wordle View Setting**\nChoose how you want Wordle results to be displayed:")
-		editMsg.ReplyMarkup = &buttons
-		editMsg.ParseMode = tgbotapi.ModeMarkdown
+		editMsg := tgbotapi.NewEditMessageReplyMarkup(chatID, callback.Message.MessageID, buttons)
 		bot.Send(editMsg)
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
 		return
@@ -1146,6 +1129,26 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "✅ Wordle view updated to **Image**.")
 		editMsg.ParseMode = tgbotapi.ModeMarkdown
 		bot.Send(editMsg)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "View set to Image"))
+		return
+	case "set_scramy_squared_new":
+		scramybot.UpdateScramyLetterView(chatID, "squared", client)
+		scramybot.RefreshActiveGameMessage(bot, chatID, callback.Message.MessageID, client)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Scramy set to Squared"))
+		return
+	case "set_scramy_normal_new":
+		scramybot.UpdateScramyLetterView(chatID, "normal", client)
+		scramybot.RefreshActiveGameMessage(bot, chatID, callback.Message.MessageID, client)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Scramy set to Normal"))
+		return
+	case "set_wordle_view_text_new":
+		wordlebot.UpdateWordleViewType(chatID, "text", client)
+		wordlebot.RefreshActiveGameMessage(bot, chatID, callback.Message.MessageID, client)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "View set to Text"))
+		return
+	case "set_wordle_view_image_new":
+		wordlebot.UpdateWordleViewType(chatID, "image", client)
+		wordlebot.RefreshActiveGameMessage(bot, chatID, callback.Message.MessageID, client)
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "View set to Image"))
 		return
 	case "wordle_start":

--- a/controller/bot.go
+++ b/controller/bot.go
@@ -1059,7 +1059,10 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 				tgbotapi.NewInlineKeyboardButtonData("Normal abc", "set_scramy_normal"),
 			),
 		)
-		view.SendMessageWithButtons(bot, chatID, "⚙️ **Scramy Letters Setting**\nChoose the letter style for Scramy:", buttons)
+		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ **Scramy Letters Setting**\nChoose the letter style for Scramy:")
+		editMsg.ReplyMarkup = &buttons
+		editMsg.ParseMode = tgbotapi.ModeMarkdown
+		bot.Send(editMsg)
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
 		return
 	case "set_scramy_squared":
@@ -1125,7 +1128,10 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 				tgbotapi.NewInlineKeyboardButtonData("Image View 🖼️", "set_wordle_view_image"),
 			),
 		)
-		view.SendMessageWithButtons(bot, chatID, "⚙️ **Wordle View Setting**\nChoose how you want Wordle results to be displayed:", buttons)
+		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ **Wordle View Setting**\nChoose how you want Wordle results to be displayed:")
+		editMsg.ReplyMarkup = &buttons
+		editMsg.ParseMode = tgbotapi.ModeMarkdown
+		bot.Send(editMsg)
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
 		return
 	case "set_wordle_view_text":

--- a/controller/bot.go
+++ b/controller/bot.go
@@ -1008,6 +1008,19 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		}
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
 		return
+	case "settings_main":
+		buttons := tgbotapi.NewInlineKeyboardMarkup(
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("Wordle View 🖼️", "setting_wordle_view"),
+				tgbotapi.NewInlineKeyboardButtonData("Scramy Letters 🔠", "setting_scramy_letters"),
+			),
+		)
+		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ **Settings**\nChoose a setting to configure:")
+		editMsg.ReplyMarkup = &buttons
+		editMsg.ParseMode = tgbotapi.ModeMarkdown
+		bot.Send(editMsg)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
+		return
 	case "mystats_main":
 		buttons := tgbotapi.NewInlineKeyboardMarkup(
 			tgbotapi.NewInlineKeyboardRow(
@@ -1028,6 +1041,9 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 			tgbotapi.NewInlineKeyboardRow(
 				tgbotapi.NewInlineKeyboardButtonData("Squared 🔠", "set_scramy_squared"),
 				tgbotapi.NewInlineKeyboardButtonData("Normal abc", "set_scramy_normal"),
+			),
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("🔙 Back", "settings_main"),
 			),
 		)
 		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ **Scramy Letters Setting**\nChoose the letter style for Scramy:")
@@ -1091,6 +1107,9 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 			tgbotapi.NewInlineKeyboardRow(
 				tgbotapi.NewInlineKeyboardButtonData("Text View 📝", "set_wordle_view_text"),
 				tgbotapi.NewInlineKeyboardButtonData("Image View 🖼️", "set_wordle_view_image"),
+			),
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("🔙 Back", "settings_main"),
 			),
 		)
 		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ **Wordle View Setting**\nChoose how you want Wordle results to be displayed:")

--- a/controller/categoryBot/categoryBot.go
+++ b/controller/categoryBot/categoryBot.go
@@ -1201,6 +1201,19 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		}
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
 		return
+	case "settings_main":
+		buttons := tgbotapi.NewInlineKeyboardMarkup(
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("Wordle View 🖼️", "setting_wordle_view"),
+				tgbotapi.NewInlineKeyboardButtonData("Scramy Letters 🔠", "setting_scramy_letters"),
+			),
+		)
+		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ **Settings**\nChoose a setting to configure:")
+		editMsg.ReplyMarkup = &buttons
+		editMsg.ParseMode = tgbotapi.ModeMarkdown
+		bot.Send(editMsg)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
+		return
 	case "mystats_main":
 		buttons := tgbotapi.NewInlineKeyboardMarkup(
 			tgbotapi.NewInlineKeyboardRow(
@@ -1221,6 +1234,9 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 			tgbotapi.NewInlineKeyboardRow(
 				tgbotapi.NewInlineKeyboardButtonData("Squared 🔠", "set_scramy_squared"),
 				tgbotapi.NewInlineKeyboardButtonData("Normal abc", "set_scramy_normal"),
+			),
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("🔙 Back", "settings_main"),
 			),
 		)
 		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ **Scramy Letters Setting**\nChoose the letter style for Scramy:")
@@ -1322,6 +1338,9 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 			tgbotapi.NewInlineKeyboardRow(
 				tgbotapi.NewInlineKeyboardButtonData("Text View 📝", "set_wordle_view_text"),
 				tgbotapi.NewInlineKeyboardButtonData("Image View 🖼️", "set_wordle_view_image"),
+			),
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("🔙 Back", "settings_main"),
 			),
 		)
 		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ **Wordle View Setting**\nChoose how you want Wordle results to be displayed:")

--- a/controller/categoryBot/categoryBot.go
+++ b/controller/categoryBot/categoryBot.go
@@ -1201,19 +1201,6 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		}
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
 		return
-	case "settings_main":
-		buttons := tgbotapi.NewInlineKeyboardMarkup(
-			tgbotapi.NewInlineKeyboardRow(
-				tgbotapi.NewInlineKeyboardButtonData("Wordle View 🖼️", "setting_wordle_view"),
-				tgbotapi.NewInlineKeyboardButtonData("Scramy Letters 🔠", "setting_scramy_letters"),
-			),
-		)
-		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ **Settings**\nChoose a setting to configure:")
-		editMsg.ReplyMarkup = &buttons
-		editMsg.ParseMode = tgbotapi.ModeMarkdown
-		bot.Send(editMsg)
-		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
-		return
 	case "mystats_main":
 		buttons := tgbotapi.NewInlineKeyboardMarkup(
 			tgbotapi.NewInlineKeyboardRow(
@@ -1248,13 +1235,11 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 	case "setting_scramy_letters_new":
 		buttons := tgbotapi.NewInlineKeyboardMarkup(
 			tgbotapi.NewInlineKeyboardRow(
-				tgbotapi.NewInlineKeyboardButtonData("Squared 🔠", "set_scramy_squared"),
-				tgbotapi.NewInlineKeyboardButtonData("Normal abc", "set_scramy_normal"),
+				tgbotapi.NewInlineKeyboardButtonData("Squared 🔠", "set_scramy_squared_new"),
+				tgbotapi.NewInlineKeyboardButtonData("Normal abc", "set_scramy_normal_new"),
 			),
 		)
-		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ **Scramy Letters Setting**\nChoose the letter style for Scramy:")
-		editMsg.ReplyMarkup = &buttons
-		editMsg.ParseMode = tgbotapi.ModeMarkdown
+		editMsg := tgbotapi.NewEditMessageReplyMarkup(chatID, callback.Message.MessageID, buttons)
 		bot.Send(editMsg)
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
 		return
@@ -1355,13 +1340,11 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 	case "setting_wordle_view_new":
 		buttons := tgbotapi.NewInlineKeyboardMarkup(
 			tgbotapi.NewInlineKeyboardRow(
-				tgbotapi.NewInlineKeyboardButtonData("Text View 📝", "set_wordle_view_text"),
-				tgbotapi.NewInlineKeyboardButtonData("Image View 🖼️", "set_wordle_view_image"),
+				tgbotapi.NewInlineKeyboardButtonData("Text View 📝", "set_wordle_view_text_new"),
+				tgbotapi.NewInlineKeyboardButtonData("Image View 🖼️", "set_wordle_view_image_new"),
 			),
 		)
-		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ **Wordle View Setting**\nChoose how you want Wordle results to be displayed:")
-		editMsg.ReplyMarkup = &buttons
-		editMsg.ParseMode = tgbotapi.ModeMarkdown
+		editMsg := tgbotapi.NewEditMessageReplyMarkup(chatID, callback.Message.MessageID, buttons)
 		bot.Send(editMsg)
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
 		return
@@ -1377,6 +1360,26 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "✅ Wordle view updated to **Image**.")
 		editMsg.ParseMode = tgbotapi.ModeMarkdown
 		bot.Send(editMsg)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "View set to Image"))
+		return
+	case "set_scramy_squared_new":
+		scramybot.UpdateScramyLetterView(chatID, "squared", client)
+		scramybot.RefreshActiveGameMessage(bot, chatID, callback.Message.MessageID, client)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Scramy set to Squared"))
+		return
+	case "set_scramy_normal_new":
+		scramybot.UpdateScramyLetterView(chatID, "normal", client)
+		scramybot.RefreshActiveGameMessage(bot, chatID, callback.Message.MessageID, client)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Scramy set to Normal"))
+		return
+	case "set_wordle_view_text_new":
+		wordlebot.UpdateWordleViewType(chatID, "text", client)
+		wordlebot.RefreshActiveGameMessage(bot, chatID, callback.Message.MessageID, client)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "View set to Text"))
+		return
+	case "set_wordle_view_image_new":
+		wordlebot.UpdateWordleViewType(chatID, "image", client)
+		wordlebot.RefreshActiveGameMessage(bot, chatID, callback.Message.MessageID, client)
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "View set to Image"))
 		return
 	case "wordle_start":

--- a/controller/categoryBot/categoryBot.go
+++ b/controller/categoryBot/categoryBot.go
@@ -1252,7 +1252,10 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 				tgbotapi.NewInlineKeyboardButtonData("Normal abc", "set_scramy_normal"),
 			),
 		)
-		view.SendMessageWithButtons(bot, chatID, "⚙️ **Scramy Letters Setting**\nChoose the letter style for Scramy:", buttons)
+		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ **Scramy Letters Setting**\nChoose the letter style for Scramy:")
+		editMsg.ReplyMarkup = &buttons
+		editMsg.ParseMode = tgbotapi.ModeMarkdown
+		bot.Send(editMsg)
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
 		return
 	case "set_scramy_squared":
@@ -1356,7 +1359,10 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 				tgbotapi.NewInlineKeyboardButtonData("Image View 🖼️", "set_wordle_view_image"),
 			),
 		)
-		view.SendMessageWithButtons(bot, chatID, "⚙️ **Wordle View Setting**\nChoose how you want Wordle results to be displayed:", buttons)
+		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ **Wordle View Setting**\nChoose how you want Wordle results to be displayed:")
+		editMsg.ReplyMarkup = &buttons
+		editMsg.ParseMode = tgbotapi.ModeMarkdown
+		bot.Send(editMsg)
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
 		return
 	case "set_wordle_view_text":

--- a/controller/scramybot/refresh.go
+++ b/controller/scramybot/refresh.go
@@ -1,0 +1,34 @@
+package scramybot
+
+import (
+	"fmt"
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// RefreshActiveGameMessage updates the active scramy game message
+func RefreshActiveGameMessage(bot *tgbotapi.BotAPI, chatID int64, messageID int, client *mongo.Client) {
+	ss := GetOrCreateScramyState(chatID)
+	ss.RLock()
+	defer ss.RUnlock()
+
+	if !ss.Active {
+		return
+	}
+
+	settings := GetChatSettings(chatID, client)
+	isSquared := settings.ScramyLetterView == "squared"
+
+	buttons := tgbotapi.NewInlineKeyboardMarkup(
+		tgbotapi.NewInlineKeyboardRow(
+			tgbotapi.NewInlineKeyboardButtonData("Change Layout ⚙️", "setting_scramy_letters_new"),
+		),
+	)
+
+	msgText := fmt.Sprintf("📝 *WORD SCRAMBLE*\n\n🦴 Make words using these letters\n\n%s\n\n🔎 Words with 4 or more letters are accepted. Longer words give more points!\n\nTotal: %d/%d", getLetterString(ss.Letters, isSquared), len(ss.FoundWords), ss.MaxWords)
+
+	editMsg := tgbotapi.NewEditMessageText(chatID, messageID, msgText)
+	editMsg.ReplyMarkup = &buttons
+	editMsg.ParseMode = tgbotapi.ModeMarkdown
+	bot.Send(editMsg)
+}

--- a/controller/wordlebot/refresh.go
+++ b/controller/wordlebot/refresh.go
@@ -1,0 +1,50 @@
+package wordlebot
+
+import (
+	"fmt"
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/wordlebot/image_generator"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// RefreshActiveGameMessage updates the active wordle game message
+func RefreshActiveGameMessage(bot *tgbotapi.BotAPI, chatID int64, messageID int, client *mongo.Client) {
+	ws := GetOrCreateWordleState(chatID)
+	ws.RLock()
+	defer ws.RUnlock()
+
+	if !ws.Active {
+		return
+	}
+
+	settings := GetChatSettings(chatID, client)
+	isImage := settings.WordleViewType == "image"
+
+	buttons := tgbotapi.NewInlineKeyboardMarkup(
+		tgbotapi.NewInlineKeyboardRow(
+			tgbotapi.NewInlineKeyboardButtonData("Change Layout ⚙️", "setting_wordle_view_new"),
+		),
+	)
+
+	// Since we can't reliably edit text into photo, we will delete and resend.
+	deleteMsg := tgbotapi.NewDeleteMessage(chatID, messageID)
+	bot.Send(deleteMsg)
+
+	if isImage {
+		imageData, err := image_generator.GenerateWordleImage(ws.Guesses, ws.Word)
+		if err == nil {
+			photo := tgbotapi.NewPhotoUpload(chatID, tgbotapi.FileBytes{Name: "wordle.png", Bytes: imageData})
+			photo.ReplyMarkup = buttons
+			bot.Send(photo)
+			return
+		}
+		// fallback to text
+	}
+
+	boardStr := buildWordleBoard(ws)
+	msgText := fmt.Sprintf("📝 *WORDLE*\n\n%s\n\nTotal: %d/6", boardStr, len(ws.Guesses))
+	msg := tgbotapi.NewMessage(chatID, msgText)
+	msg.ReplyMarkup = buttons
+	msg.ParseMode = tgbotapi.ModeMarkdown
+	bot.Send(msg)
+}


### PR DESCRIPTION
💡 What: Added a "🔙 Back" button to the Scramy Letters and Wordle View sub-menus, pointing back to the main Settings menu.
🎯 Why: Without a back button, users are stranded in the sub-menus and must dismiss the prompt and type `/settings` again to return to the main settings page. This micro-UX change creates a much smoother navigation loop.
♿ Accessibility: Improved keyboard/inline navigation flow without dead ends.

---
*PR created automatically by Jules for task [4371099062891646489](https://jules.google.com/task/4371099062891646489) started by @MUSTAFA-A-KHAN*