### PR TITLE
🔨 Forge: Fix missing back navigation in settings menu

### DIFF
--- a/.Jules/forge.md
+++ b/.Jules/forge.md
@@ -8,3 +8,7 @@ Action: Always look for opportunities to replace  or similar new-message functio
 Learning: When building Telegram Bot conversational interfaces, it's a better user experience to edit an existing message with updated content (like showing an inventory screen after a purchase) instead of sending entirely new messages, which pushes previous buttons up and clutters the chat history.
 
 Action: Always look for opportunities to replace 'showShop' or similar new-message functions with in-place edits (e.g., 'showInventory' which edits the message) when handling callbacks within a single, continuous user workflow.
+## 2023-10-25 - Fixing Missing Navigation in Settings
+
+**Learning:** When navigating between different views with inline keyboards, make sure all "Back" button callbacks (like `settings_main`) are actually handled in the main `switch callback.Data` block. It can easily be missed when refactoring or adding new settings menus.
+**Action:** Always check the full lifecycle of navigation flows and ensure all button paths have defined handlers.

--- a/controller/bot.go
+++ b/controller/bot.go
@@ -1090,6 +1090,19 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		bot.Send(editMsg)
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
 		return
+	case "settings_main":
+		buttons := tgbotapi.NewInlineKeyboardMarkup(
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("Wordle View 🖼️", "setting_wordle_view"),
+				tgbotapi.NewInlineKeyboardButtonData("Scramy Letters 🔠", "setting_scramy_letters"),
+			),
+		)
+		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ *Settings*\nChoose a setting to configure:")
+		editMsg.ReplyMarkup = &buttons
+		editMsg.ParseMode = tgbotapi.ModeMarkdown
+		bot.Send(editMsg)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
+		return
 	case "setting_wordle_view":
 		buttons := tgbotapi.NewInlineKeyboardMarkup(
 			tgbotapi.NewInlineKeyboardRow(

--- a/controller/categoryBot/categoryBot.go
+++ b/controller/categoryBot/categoryBot.go
@@ -1321,6 +1321,19 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		chatState.Unlock()
 			saveCategoryChatStateAsync(chatID, chatState)
 		bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, chatState.Word))
+	case "settings_main":
+		buttons := tgbotapi.NewInlineKeyboardMarkup(
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("Wordle View 🖼️", "setting_wordle_view"),
+				tgbotapi.NewInlineKeyboardButtonData("Scramy Letters 🔠", "setting_scramy_letters"),
+			),
+		)
+		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ *Settings*\nChoose a setting to configure:")
+		editMsg.ReplyMarkup = &buttons
+		editMsg.ParseMode = tgbotapi.ModeMarkdown
+		bot.Send(editMsg)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
+		return
 	case "setting_wordle_view":
 		buttons := tgbotapi.NewInlineKeyboardMarkup(
 			tgbotapi.NewInlineKeyboardRow(


### PR DESCRIPTION
**Problem**
When users navigated to a sub-menu in the settings (e.g., "Wordle View" or "Scramy Letters"), clicking the "🔙 Back" button did nothing. The callback data `"settings_main"` was being emitted, but there was no corresponding case in the `handleCallbackQuery` switch statement to process it.

**Solution**
Added a `case "settings_main":` block to `handleCallbackQuery` in both `controller/bot.go` and `controller/categoryBot/categoryBot.go`. This case re-renders the main settings menu inline keyboard and text. The bold text format was also adjusted to use standard Markdown single asterisks (`*Settings*`) for compatibility with `tgbotapi.ModeMarkdown`.

**Impact**
This restores broken user navigation, allowing users to return to the main settings menu without having to re-issue the `/setting` command.

**Alternatives Considered**
No alternative implementations were considered since handling the explicitly defined callback data is the standard mechanism for inline keyboard navigation in this project. 

**Validation**
- Build results: Passed (`go build -v ./...`)
- Test results: Passed (`go test -race ./...`)
- Manual verification: Verified the `switch` statements have the correct logic.

---
*PR created automatically by Jules for task [15480814474665260104](https://jules.google.com/task/15480814474665260104) started by @MUSTAFA-A-KHAN*