### PR TITLE
🎨 Pixel: Better Leaderboard Spacing

### DIFF
--- a/.Jules/pixel.md
+++ b/.Jules/pixel.md
@@ -1,0 +1,5 @@
+## 2024-06-07 - Better Spacing in Leaderboards
+
+**Learning:** Leaderboards look messy when names and scores aren't aligned and Unicode emojis mess up monospace alignment in `<pre>` tags.
+
+**Action:** Removed `<pre>` tags and manual padding from leaderboards. Used a simple inline layout pattern (`<b>[rank]</b> [name] — [score]`) to ensure clean rendering on Telegram clients.

--- a/service/leaderBoardList.go
+++ b/service/leaderBoardList.go
@@ -24,9 +24,6 @@ func LeaderBoardList(client *mongo.Client, collection string, chatID int64) stri
 	rankEmojis := []string{"🥇", "🥈", "🥉"}
 
 	leaderboard := "🏆 <b>Top 10 Players Leaderboard</b> 🏆\n\n"
-	leaderboard += "<pre>"
-	leaderboard += fmt.Sprintf("%-6s | %-20s | %s\n", "Rank", "Player", "Score")
-	leaderboard += strings.Repeat("─", 38) + "\n"
 
 	for i := 0; i < limit; i++ {
 		count := idCounts[i]
@@ -60,10 +57,9 @@ func LeaderBoardList(client *mongo.Client, collection string, chatID int64) stri
 		} else {
 			rankDisplay = "⭐ " + rankDisplay
 		}
-		leaderboard += fmt.Sprintf("%-6s | %-20s | %s\n", rankDisplay, name, score)
+		leaderboard += fmt.Sprintf("<b>%s</b> %s — %s\n", rankDisplay, name, score)
 	}
 
-	leaderboard += "</pre>"
 	leaderboard += "\n✨ <b>Keep it up and aim for the top!</b> ✨\n"
 
 	return leaderboard


### PR DESCRIPTION
### 💡 What
Removed `<pre>` formatting and manual padding from leaderboards in `service/leaderBoardList.go`. Used a simple inline HTML layout pattern: `<b>[rank]</b> [name] — [score]`.

### 🎯 Why
Fixed-width tables look messy in Telegram, especially when names and scores aren't perfectly aligned, and Unicode emojis frequently break monospace character alignment inside `<pre>` blocks.

### 📸 Before
```text
<pre>
Rank   | Player               | Score
──────────────────────────────────────
🥇     | Alice                | 150 🪙
🥈     | Bob 🌟               | 90
</pre>
```

### ✨ After
<b>🥇</b> Alice — 150 🪙
<b>🥈</b> Bob 🌟 — 90

### 📱 Mobile
This ensures the leaderboard uses the client's native fonts and line wrapping cleanly without requiring horizontal scrolling, making it much more readable on mobile Telegram clients.

---
*PR created automatically by Jules for task [6475910128999995282](https://jules.google.com/task/6475910128999995282) started by @MUSTAFA-A-KHAN*