### PR TITLE
🎨 Palette: Add missing navigation callback for Settings menu

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -3,3 +3,6 @@
 **Learning:** When users launch sub-menus from a main settings menu, failing to provide a back button leads to a frustrating experience where they must dismiss the prompt and re-open the settings menu from scratch.
 
 **Action:** Ensure all multi-level inline keyboard menus have a "🔙 Back" button to smoothly return to the previous level without abandoning the menu structure entirely.
+## 2024-06-07 - Add missing navigation entry for settings menu
+**Learning:** Telegram inline menus that use "Back" navigation rely entirely on mapping a callback data string (e.g., `settings_main`) to a `tgbotapi.NewEditMessageText` action. If the root menu is launched via a text command (`/settings`) but lacks a corresponding callback handler in the `switch` statement for the `Back` button, users become trapped in sub-menus. The `tgbotapi` wrapper library swallows unhandled callbacks silently rather than throwing errors.
+**Action:** When designing nested inline keyboards in Telegram, always ensure that the root entry point has a corresponding `callback.Data` case registered in the main message loop so users can navigate back out of leaf nodes.

--- a/controller/bot.go
+++ b/controller/bot.go
@@ -1023,6 +1023,19 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		bot.Send(editMsg)
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
 		return
+	case "settings_main":
+		buttons := tgbotapi.NewInlineKeyboardMarkup(
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("Wordle View 🖼️", "setting_wordle_view"),
+				tgbotapi.NewInlineKeyboardButtonData("Scramy Letters 🔠", "setting_scramy_letters"),
+			),
+		)
+		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ *Settings*\nChoose a setting to configure:")
+		editMsg.ReplyMarkup = &buttons
+		editMsg.ParseMode = tgbotapi.ModeMarkdown
+		bot.Send(editMsg)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
+		return
 	case "setting_scramy_letters":
 		buttons := tgbotapi.NewInlineKeyboardMarkup(
 			tgbotapi.NewInlineKeyboardRow(

--- a/controller/categoryBot/categoryBot.go
+++ b/controller/categoryBot/categoryBot.go
@@ -1216,6 +1216,19 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		bot.Send(editMsg)
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
 		return
+	case "settings_main":
+		buttons := tgbotapi.NewInlineKeyboardMarkup(
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("Wordle View 🖼️", "setting_wordle_view"),
+				tgbotapi.NewInlineKeyboardButtonData("Scramy Letters 🔠", "setting_scramy_letters"),
+			),
+		)
+		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ *Settings*\nChoose a setting to configure:")
+		editMsg.ReplyMarkup = &buttons
+		editMsg.ParseMode = tgbotapi.ModeMarkdown
+		bot.Send(editMsg)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
+		return
 	case "setting_scramy_letters":
 		buttons := tgbotapi.NewInlineKeyboardMarkup(
 			tgbotapi.NewInlineKeyboardRow(


### PR DESCRIPTION
🎨 Palette: Add missing navigation callback for Settings menu

💡 What: Implemented the missing `settings_main` callback handler to support backward navigation in the Settings menu. Also fixed broken markdown rendering for the bold text `**Settings**`.
🎯 Why: Users who clicked into `Wordle View` or `Scramy Letters` sub-menus were getting trapped. Clicking the "Back" button did nothing because the callback data was unhandled by the bot's switch statement.
📸 Before/After: The back button now successfully re-renders the root Settings menu.
♿ Accessibility: Ensures consistent and fully functional keyboard navigation within inline menus.

---
*PR created automatically by Jules for task [12977291013910833686](https://jules.google.com/task/12977291013910833686) started by @MUSTAFA-A-KHAN*