### PR TITLE
feat: Replace send+delete with editMessageMedia for inline image updates

### DIFF
--- a/controller/bot.go
+++ b/controller/bot.go
@@ -1037,11 +1037,14 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Generating image..."))
 		imgBytes, err := service.GenerateLeaderboardImage(client, "CrocEn", 0, "Word Guess Global Leaderboard")
 		if err == nil {
-			photo := tgbotapi.NewPhotoUpload(chatID, tgbotapi.FileBytes{Name: "leaderboard.png", Bytes: imgBytes})
-			photo.ReplyMarkup = markup
-
-			bot.Send(photo)
-			bot.Send(tgbotapi.NewDeleteMessage(chatID, callback.Message.MessageID))
+			err = view.EditMessageMediaWithStyledButtons(bot.Token, chatID, callback.Message.MessageID, imgBytes, "leaderboard.png", &markup)
+			if err != nil {
+				// Fallback if message wasn't a photo previously
+				photo := tgbotapi.NewPhotoUpload(chatID, tgbotapi.FileBytes{Name: "leaderboard.png", Bytes: imgBytes})
+				photo.ReplyMarkup = markup
+				bot.Send(photo)
+				bot.Send(tgbotapi.NewDeleteMessage(chatID, callback.Message.MessageID))
+			}
 		} else {
 			view.SendMessage(bot, chatID, "Failed to generate image.")
 		}
@@ -1051,11 +1054,14 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Generating image..."))
 		imgBytes, err := service.GenerateLeaderboardImage(client, "WordleEn", 0, "Wordle Global Leaderboard")
 		if err == nil {
-			photo := tgbotapi.NewPhotoUpload(chatID, tgbotapi.FileBytes{Name: "leaderboard.png", Bytes: imgBytes})
-			photo.ReplyMarkup = markup
-
-			bot.Send(photo)
-			bot.Send(tgbotapi.NewDeleteMessage(chatID, callback.Message.MessageID))
+			err = view.EditMessageMediaWithStyledButtons(bot.Token, chatID, callback.Message.MessageID, imgBytes, "leaderboard.png", &markup)
+			if err != nil {
+				// Fallback if message wasn't a photo previously
+				photo := tgbotapi.NewPhotoUpload(chatID, tgbotapi.FileBytes{Name: "leaderboard.png", Bytes: imgBytes})
+				photo.ReplyMarkup = markup
+				bot.Send(photo)
+				bot.Send(tgbotapi.NewDeleteMessage(chatID, callback.Message.MessageID))
+			}
 		} else {
 			view.SendMessage(bot, chatID, "Failed to generate image.")
 		}
@@ -1065,11 +1071,14 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Generating image..."))
 		imgBytes, err := service.GenerateLeaderboardImage(client, "ScramyEn", 0, "Scramy Global Leaderboard")
 		if err == nil {
-			photo := tgbotapi.NewPhotoUpload(chatID, tgbotapi.FileBytes{Name: "leaderboard.png", Bytes: imgBytes})
-			photo.ReplyMarkup = markup
-
-			bot.Send(photo)
-			bot.Send(tgbotapi.NewDeleteMessage(chatID, callback.Message.MessageID))
+			err = view.EditMessageMediaWithStyledButtons(bot.Token, chatID, callback.Message.MessageID, imgBytes, "leaderboard.png", &markup)
+			if err != nil {
+				// Fallback if message wasn't a photo previously
+				photo := tgbotapi.NewPhotoUpload(chatID, tgbotapi.FileBytes{Name: "leaderboard.png", Bytes: imgBytes})
+				photo.ReplyMarkup = markup
+				bot.Send(photo)
+				bot.Send(tgbotapi.NewDeleteMessage(chatID, callback.Message.MessageID))
+			}
 		} else {
 			view.SendMessage(bot, chatID, "Failed to generate image.")
 		}
@@ -1079,11 +1088,14 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Generating image..."))
 		imgBytes, err := service.GenerateLeaderboardImage(client, "CrocEn", chatID, "Word Guess Group Leaderboard")
 		if err == nil {
-			photo := tgbotapi.NewPhotoUpload(chatID, tgbotapi.FileBytes{Name: "leaderboard.png", Bytes: imgBytes})
-			photo.ReplyMarkup = markup
-
-			bot.Send(photo)
-			bot.Send(tgbotapi.NewDeleteMessage(chatID, callback.Message.MessageID))
+			err = view.EditMessageMediaWithStyledButtons(bot.Token, chatID, callback.Message.MessageID, imgBytes, "leaderboard.png", &markup)
+			if err != nil {
+				// Fallback if message wasn't a photo previously
+				photo := tgbotapi.NewPhotoUpload(chatID, tgbotapi.FileBytes{Name: "leaderboard.png", Bytes: imgBytes})
+				photo.ReplyMarkup = markup
+				bot.Send(photo)
+				bot.Send(tgbotapi.NewDeleteMessage(chatID, callback.Message.MessageID))
+			}
 		} else {
 			view.SendMessage(bot, chatID, "Failed to generate image.")
 		}
@@ -1093,11 +1105,14 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Generating image..."))
 		imgBytes, err := service.GenerateLeaderboardImage(client, "WordleEn", chatID, "Wordle Group Leaderboard")
 		if err == nil {
-			photo := tgbotapi.NewPhotoUpload(chatID, tgbotapi.FileBytes{Name: "leaderboard.png", Bytes: imgBytes})
-			photo.ReplyMarkup = markup
-
-			bot.Send(photo)
-			bot.Send(tgbotapi.NewDeleteMessage(chatID, callback.Message.MessageID))
+			err = view.EditMessageMediaWithStyledButtons(bot.Token, chatID, callback.Message.MessageID, imgBytes, "leaderboard.png", &markup)
+			if err != nil {
+				// Fallback if message wasn't a photo previously
+				photo := tgbotapi.NewPhotoUpload(chatID, tgbotapi.FileBytes{Name: "leaderboard.png", Bytes: imgBytes})
+				photo.ReplyMarkup = markup
+				bot.Send(photo)
+				bot.Send(tgbotapi.NewDeleteMessage(chatID, callback.Message.MessageID))
+			}
 		} else {
 			view.SendMessage(bot, chatID, "Failed to generate image.")
 		}
@@ -1107,11 +1122,14 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Generating image..."))
 		imgBytes, err := service.GenerateLeaderboardImage(client, "ScramyEn", chatID, "Scramy Group Leaderboard")
 		if err == nil {
-			photo := tgbotapi.NewPhotoUpload(chatID, tgbotapi.FileBytes{Name: "leaderboard.png", Bytes: imgBytes})
-			photo.ReplyMarkup = markup
-
-			bot.Send(photo)
-			bot.Send(tgbotapi.NewDeleteMessage(chatID, callback.Message.MessageID))
+			err = view.EditMessageMediaWithStyledButtons(bot.Token, chatID, callback.Message.MessageID, imgBytes, "leaderboard.png", &markup)
+			if err != nil {
+				// Fallback if message wasn't a photo previously
+				photo := tgbotapi.NewPhotoUpload(chatID, tgbotapi.FileBytes{Name: "leaderboard.png", Bytes: imgBytes})
+				photo.ReplyMarkup = markup
+				bot.Send(photo)
+				bot.Send(tgbotapi.NewDeleteMessage(chatID, callback.Message.MessageID))
+			}
 		} else {
 			view.SendMessage(bot, chatID, "Failed to generate image.")
 		}

--- a/controller/wordlebot/refresh.go
+++ b/controller/wordlebot/refresh.go
@@ -5,6 +5,7 @@ import (
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/wordlebot/image_generator"
 	"go.mongodb.org/mongo-driver/mongo"
+	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/view"
 )
 
 // RefreshActiveGameMessage updates the active wordle game message
@@ -26,20 +27,27 @@ func RefreshActiveGameMessage(bot *tgbotapi.BotAPI, chatID int64, messageID int,
 		),
 	)
 
-	// Since we can't reliably edit text into photo, we will delete and resend.
-	deleteMsg := tgbotapi.NewDeleteMessage(chatID, messageID)
-	bot.Send(deleteMsg)
-
 	if isImage {
 		imageData, err := image_generator.GenerateWordleImage(ws.Guesses, ws.Word)
 		if err == nil {
-			photo := tgbotapi.NewPhotoUpload(chatID, tgbotapi.FileBytes{Name: "wordle.png", Bytes: imageData})
-			photo.ReplyMarkup = buttons
-			bot.Send(photo)
+			err = view.EditMessageMediaWithStyledButtons(bot.Token, chatID, messageID, imageData, "wordle.png", &buttons)
+			if err != nil {
+				// Fallback if message wasn't a photo previously
+				deleteMsg := tgbotapi.NewDeleteMessage(chatID, messageID)
+				bot.Send(deleteMsg)
+
+				photo := tgbotapi.NewPhotoUpload(chatID, tgbotapi.FileBytes{Name: "wordle.png", Bytes: imageData})
+				photo.ReplyMarkup = buttons
+				bot.Send(photo)
+			}
 			return
 		}
 		// fallback to text
 	}
+
+	// If not image, delete and resend text
+	deleteMsg := tgbotapi.NewDeleteMessage(chatID, messageID)
+	bot.Send(deleteMsg)
 
 	boardStr := buildWordleBoard(ws)
 	msgText := fmt.Sprintf("📝 *WORDLE*\n\n%s\n\nTotal: %d/6", boardStr, len(ws.Guesses))

--- a/view/edit_media.go
+++ b/view/edit_media.go
@@ -1,0 +1,78 @@
+package view
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"mime/multipart"
+	"net/http"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+)
+
+func EditMessageMediaWithStyledButtons(botToken string, chatID int64, messageID int, media []byte, filename string, markup *tgbotapi.InlineKeyboardMarkup) error {
+	url := fmt.Sprintf("https://api.telegram.org/bot%s/editMessageMedia", botToken)
+
+	var b bytes.Buffer
+	w := multipart.NewWriter(&b)
+
+	// Add chat_id and message_id
+	w.WriteField("chat_id", fmt.Sprintf("%d", chatID))
+	w.WriteField("message_id", fmt.Sprintf("%d", messageID))
+
+	// Add media details as JSON string
+	mediaDetails := map[string]interface{}{
+		"type":  "photo",
+		"media": "attach://" + filename,
+	}
+	mediaJSON, err := json.Marshal(mediaDetails)
+	if err != nil {
+		return err
+	}
+	w.WriteField("media", string(mediaJSON))
+
+	if markup != nil {
+		markupJSON, err := json.Marshal(markup)
+		if err != nil {
+			return err
+		}
+		w.WriteField("reply_markup", string(markupJSON))
+	}
+
+	// Add actual file
+	fw, err := w.CreateFormFile(filename, filename)
+	if err != nil {
+		return err
+	}
+	if _, err = io.Copy(fw, bytes.NewReader(media)); err != nil {
+		return err
+	}
+
+	w.Close()
+
+	req, err := http.NewRequest("POST", url, &b)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", w.FormDataContentType())
+
+	client := &http.Client{}
+	res, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		bodyBytes, _ := io.ReadAll(res.Body)
+		if bytes.Contains(bodyBytes, []byte("message is not modified")) {
+			return nil
+		}
+		log.Printf("Telegram API responded with status: %s, body: %s", res.Status, string(bodyBytes))
+		return fmt.Errorf("Telegram API responded with status: %s", res.Status)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR fulfills the user request to edit existing messages containing dynamically generated media rather than deleting the original and sending a new message. Because upgrading the Telegram Bot API library to v5 caused breaking compilation issues in other unrelated files (due to `bot.MakeRequest` params), a custom HTTP multipart file uploader implementation (`view.EditMessageMediaWithStyledButtons`) was introduced to cleanly access the API endpoint. Fallback handling ensures zero regressions if an edit isn't permitted by Telegram APIs.

---
*PR created automatically by Jules for task [5690449110024586178](https://jules.google.com/task/5690449110024586178) started by @MUSTAFA-A-KHAN*