### PR TITLE
🔨 Forge: Display user balance in Emoji Shop

### DIFF
--- a/.Jules/forge.md
+++ b/.Jules/forge.md
@@ -12,3 +12,8 @@ Action: Always look for opportunities to replace 'showShop' or similar new-messa
 
 **Learning:** When navigating between different views with inline keyboards, make sure all "Back" button callbacks (like `settings_main`) are actually handled in the main `switch callback.Data` block. It can easily be missed when refactoring or adding new settings menus.
 **Action:** Always check the full lifecycle of navigation flows and ensure all button paths have defined handlers.
+
+2024-10-18 - Display User Balance in Shop Interfaces
+
+Learning: When building an economy feature like an in-game shop, users must be able to view their available currency balance within the shop interface itself to prevent failed purchases and friction.
+Action: Updated the `showShop` and `editShopMain` functions to fetch and present the user's `Wordle Points` balance prominently when the shop menu is rendered.

--- a/controller/bot.go
+++ b/controller/bot.go
@@ -301,7 +301,7 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 		case "start":
 			args := message.CommandArguments()
 			if args == "shop" {
-				showShop(bot, message.Chat.ID)
+				showShop(bot, message.Chat.ID, message.From.ID, client)
 				return
 			} else if strings.HasPrefix(args, "custom_word_") {
 				parts := strings.Split(args, "_")
@@ -382,7 +382,7 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 		case "shop":
 			if message.Chat.IsPrivate() {
 				// Handle shop in DM
-				showShop(bot, message.Chat.ID)
+				showShop(bot, message.Chat.ID, message.From.ID, client)
 			} else {
 				// Send a link to DM
 				botUsername := bot.Self.UserName
@@ -680,7 +680,7 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 		}
 	case "start":
 		if message.CommandArguments() == "shop" {
-			showShop(bot, message.Chat.ID)
+			showShop(bot, message.Chat.ID, message.From.ID, client)
 		} else {
 			view.SendMessage(bot, message.Chat.ID, "Welcome! Type /word to start a new game.")
 		}
@@ -709,7 +709,7 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 	case "shop":
 		if message.Chat.IsPrivate() {
 			// Handle shop in DM
-			showShop(bot, message.Chat.ID)
+			showShop(bot, message.Chat.ID, message.From.ID, client)
 		} else {
 			// Send a link to DM
 			botUsername := bot.Self.UserName

--- a/controller/categoryBot/categoryBot.go
+++ b/controller/categoryBot/categoryBot.go
@@ -364,7 +364,7 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 		case "start":
 			args := message.CommandArguments()
 			if args == "shop" {
-				showShop(bot, message.Chat.ID)
+				showShop(bot, message.Chat.ID, message.From.ID, client)
 				return
 			} else if strings.HasPrefix(args, "custom_word_") {
 				parts := strings.Split(args, "_")
@@ -451,7 +451,7 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 		case "shop":
 			if message.Chat.IsPrivate() {
 				// Handle shop in DM
-				showShop(bot, message.Chat.ID)
+				showShop(bot, message.Chat.ID, message.From.ID, client)
 			} else {
 				// Send a link to DM
 				botUsername := bot.Self.UserName
@@ -804,7 +804,7 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 		return
 	case "start":
 		if message.CommandArguments() == "shop" {
-			showShop(bot, message.Chat.ID)
+			showShop(bot, message.Chat.ID, message.From.ID, client)
 		} else {
 			view.SendMessage(bot, message.Chat.ID, "Welcome! Type /word to start a new game.")
 		}
@@ -840,7 +840,7 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 	case "shop":
 		if message.Chat.IsPrivate() {
 			// Handle shop in DM
-			showShop(bot, message.Chat.ID)
+			showShop(bot, message.Chat.ID, message.From.ID, client)
 		} else {
 			// Send a link to DM
 			botUsername := bot.Self.UserName

--- a/controller/categoryBot/shopCallback.go
+++ b/controller/categoryBot/shopCallback.go
@@ -17,7 +17,7 @@ func handleShopCallback(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery, 
 		showInventory(bot, callback, client)
 		return true
 	} else if data == "shop_main" {
-		editShopMain(bot, callback)
+		editShopMain(bot, callback, client)
 		return true
 	} else if strings.HasPrefix(data, "buy_emoji_") {
 		emoji := strings.TrimPrefix(data, "buy_emoji_")
@@ -32,7 +32,7 @@ func handleShopCallback(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery, 
 	return false
 }
 
-func editShopMain(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery) {
+func editShopMain(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery, client *mongo.Client) {
 	var rows [][]tgbotapi.InlineKeyboardButton
 
 	// Add inventory button
@@ -57,7 +57,10 @@ func editShopMain(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery) {
 
 	markup := tgbotapi.NewInlineKeyboardMarkup(rows...)
 
-	editMsg := tgbotapi.NewEditMessageText(callback.Message.Chat.ID, callback.Message.MessageID, "🛒 *Welcome to the Emoji Shop!*\n\nSpend your Wordle Points here to buy custom emojis that will appear next to your name on leaderboards.")
+	points := repository.GetCurrentPoints(client, int(callback.From.ID))
+	text := fmt.Sprintf("🛒 *Welcome to the Emoji Shop!*\n\nSpend your Wordle Points here to buy custom emojis that will appear next to your name on leaderboards.\n\n💰 *Your Balance:* %d 🪙", points)
+
+	editMsg := tgbotapi.NewEditMessageText(callback.Message.Chat.ID, callback.Message.MessageID, text)
 	editMsg.ReplyMarkup = &markup
 	editMsg.ParseMode = "Markdown"
 	bot.Send(editMsg)

--- a/controller/categoryBot/shopUI.go
+++ b/controller/categoryBot/shopUI.go
@@ -2,12 +2,14 @@ package categorybot
 
 import (
 	"fmt"
+	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/repository"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/service"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/view"
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+	"go.mongodb.org/mongo-driver/mongo"
 )
 
-func showShop(bot *tgbotapi.BotAPI, chatID int64) {
+func showShop(bot *tgbotapi.BotAPI, chatID int64, userID int, client *mongo.Client) {
 	var rows [][]tgbotapi.InlineKeyboardButton
 
 	// Add inventory button
@@ -31,5 +33,9 @@ func showShop(bot *tgbotapi.BotAPI, chatID int64) {
 	}
 
 	markup := tgbotapi.NewInlineKeyboardMarkup(rows...)
-	view.SendMessageWithButtons(bot, chatID, "🛒 *Welcome to the Emoji Shop!*\n\nSpend your Wordle Points here to buy custom emojis that will appear next to your name on leaderboards.", markup)
+
+	points := repository.GetCurrentPoints(client, userID)
+	text := fmt.Sprintf("🛒 *Welcome to the Emoji Shop!*\n\nSpend your Wordle Points here to buy custom emojis that will appear next to your name on leaderboards.\n\n💰 *Your Balance:* %d 🪙", points)
+
+	view.SendMessageWithButtons(bot, chatID, text, markup)
 }

--- a/controller/shopCallback.go
+++ b/controller/shopCallback.go
@@ -17,7 +17,7 @@ func handleShopCallback(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery, 
 		showInventory(bot, callback, client)
 		return true
 	} else if data == "shop_main" {
-		editShopMain(bot, callback)
+		editShopMain(bot, callback, client)
 		return true
 	} else if strings.HasPrefix(data, "buy_emoji_") {
 		emoji := strings.TrimPrefix(data, "buy_emoji_")
@@ -32,7 +32,7 @@ func handleShopCallback(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery, 
 	return false
 }
 
-func editShopMain(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery) {
+func editShopMain(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery, client *mongo.Client) {
 	var rows [][]tgbotapi.InlineKeyboardButton
 
 	// Add inventory button
@@ -57,7 +57,10 @@ func editShopMain(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery) {
 
 	markup := tgbotapi.NewInlineKeyboardMarkup(rows...)
 
-	editMsg := tgbotapi.NewEditMessageText(callback.Message.Chat.ID, callback.Message.MessageID, "🛒 *Welcome to the Emoji Shop!*\n\nSpend your Wordle Points here to buy custom emojis that will appear next to your name on leaderboards.")
+	points := repository.GetCurrentPoints(client, int(callback.From.ID))
+	text := fmt.Sprintf("🛒 *Welcome to the Emoji Shop!*\n\nSpend your Wordle Points here to buy custom emojis that will appear next to your name on leaderboards.\n\n💰 *Your Balance:* %d 🪙", points)
+
+	editMsg := tgbotapi.NewEditMessageText(callback.Message.Chat.ID, callback.Message.MessageID, text)
 	editMsg.ReplyMarkup = &markup
 	editMsg.ParseMode = "Markdown"
 	bot.Send(editMsg)

--- a/controller/shopUI.go
+++ b/controller/shopUI.go
@@ -2,12 +2,14 @@ package controller
 
 import (
 	"fmt"
+	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/repository"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/service"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/view"
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+	"go.mongodb.org/mongo-driver/mongo"
 )
 
-func showShop(bot *tgbotapi.BotAPI, chatID int64) {
+func showShop(bot *tgbotapi.BotAPI, chatID int64, userID int, client *mongo.Client) {
 	var rows [][]tgbotapi.InlineKeyboardButton
 
 	// Add inventory button
@@ -31,5 +33,9 @@ func showShop(bot *tgbotapi.BotAPI, chatID int64) {
 	}
 
 	markup := tgbotapi.NewInlineKeyboardMarkup(rows...)
-	view.SendMessageWithButtons(bot, chatID, "🛒 *Welcome to the Emoji Shop!*\n\nSpend your Wordle Points here to buy custom emojis that will appear next to your name on leaderboards.", markup)
+
+	points := repository.GetCurrentPoints(client, userID)
+	text := fmt.Sprintf("🛒 *Welcome to the Emoji Shop!*\n\nSpend your Wordle Points here to buy custom emojis that will appear next to your name on leaderboards.\n\n💰 *Your Balance:* %d 🪙", points)
+
+	view.SendMessageWithButtons(bot, chatID, text, markup)
 }


### PR DESCRIPTION
Problem
Users previously had no way to view their available Wordle Points balance when browsing the Emoji Shop, leading to friction and failed purchase attempts due to insufficient funds.

Solution
Modified the `showShop` and `editShopMain` callback handlers to query the database using `repository.GetCurrentPoints` and inject the user's available balance into the shop interface's Markdown description.

Impact
Noticeably improves shop usability by providing immediate, real-time feedback on user purchasing power without requiring them to trigger a secondary "/stats" command or blindly attempt a purchase.

Alternatives Considered
I considered cleaning up stale inline buttons ("Start Wordle" / "Cancel") from chat history when a game is canceled via callback. However, adding balance visibility to a live shop economy provides a far more prominent and valuable user experience improvement than removing a stale UI element.

Validation
- Build results: Passed (`go build -v ./...`)
- Test results: Passed (`go test ./...`)
- Manual verification: Double-checked `showShop` and `editShopMain` argument updates propagate cleanly to `handleCallbackQuery` and `/shop` entry points in both `controller/bot.go` and `controller/categoryBot/categoryBot.go`.

---
*PR created automatically by Jules for task [6450379640216002412](https://jules.google.com/task/6450379640216002412) started by @MUSTAFA-A-KHAN*