### PR TITLE
🔨 Forge: Support standard Wordle black and white square emojis in Eordle parser

### DIFF
--- a/.Jules/forge.md
+++ b/.Jules/forge.md
@@ -17,3 +17,7 @@ Action: Always look for opportunities to replace 'showShop' or similar new-messa
 
 Learning: When building an economy feature like an in-game shop, users must be able to view their available currency balance within the shop interface itself to prevent failed purchases and friction.
 Action: Updated the `showShop` and `editShopMain` functions to fetch and present the user's `Wordle Points` balance prominently when the shop menu is rendered.
+
+YYYY-MM-DD - Better Wordle Parsing
+Learning: Standard Wordle copies often use ⬛ (Black Square) and ⬜ (White Square) instead of 🟥 for missed/absent letters.
+Action: When parsing or evaluating Wordle/Eordle game board feedback emojis, always account for standard 'miss' characters like the black square (⬛, U+2B1B) and the white square (⬜, U+2B1C) in addition to the standard colored sequence emojis.

--- a/controller/translator/eordle.go
+++ b/controller/translator/eordle.go
@@ -151,14 +151,14 @@ func parseConstraints(puzzle string) (string, []rune, []rune, []map[rune]bool) {
 		}
 		var emojis []rune
 		for _, r := range line {
-			if r == '🟩' || r == '🟨' || r == '🟥' {
+			if r == '🟩' || r == '🟨' || r == '🟥' || r == '⬛' || r == '⬜' {
 				emojis = append(emojis, r)
 			}
 		}
 		if len(emojis) < 5 {
 			for _, tok := range strings.Fields(line) {
 				for _, r := range tok {
-					if r == '🟩' || r == '🟨' || r == '🟥' {
+					if r == '🟩' || r == '🟨' || r == '🟥' || r == '⬛' || r == '⬜' {
 						emojis = append(emojis, r)
 					}
 				}
@@ -187,7 +187,7 @@ func parseConstraints(puzzle string) (string, []rune, []rune, []map[rune]bool) {
 				if excludedMap[ch] {
 					delete(excludedMap, ch)
 				}
-			case '🟥':
+			case '🟥', '⬛', '⬜':
 				if !presentMap[ch] {
 					excludedMap[ch] = true
 				}
@@ -422,7 +422,7 @@ func (t *TextTranslator) AnalyzeEordle(puzzle string) string {
 		// collect emoji feedback runes in order
 		var emojis []rune
 		for _, r := range line {
-			if r == '🟩' || r == '🟨' || r == '🟥' {
+			if r == '🟩' || r == '🟨' || r == '🟥' || r == '⬛' || r == '⬜' {
 				emojis = append(emojis, r)
 			}
 		}
@@ -431,7 +431,7 @@ func (t *TextTranslator) AnalyzeEordle(puzzle string) string {
 		if len(emojis) < 5 {
 			for _, tok := range strings.Fields(line) {
 				for _, r := range tok {
-					if r == '🟩' || r == '🟨' || r == '🟥' {
+					if r == '🟩' || r == '🟨' || r == '🟥' || r == '⬛' || r == '⬜' {
 						emojis = append(emojis, r)
 					}
 				}
@@ -456,7 +456,7 @@ func (t *TextTranslator) AnalyzeEordle(puzzle string) string {
 			case '🟨':
 				present[ch] = true
 				delete(excluded, ch)
-			case '🟥':
+			case '🟥', '⬛', '⬜':
 				// tentatively excluded; we'll remove if seen as present/green later
 				if !present[ch] {
 					excluded[ch] = true

--- a/controller/translator/handlers_test.go
+++ b/controller/translator/handlers_test.go
@@ -1,6 +1,44 @@
 package translator
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
+
+func TestAnalyzeEordleConstraints(t *testing.T) {
+	trans := &TextTranslator{}
+
+	// Test 1: Standard Red squares
+	inputRed := "🟩 🟥 🟥 🟥 🟥 GREEN\n🟨 🟥 🟥 🟥 🟥 YELLO\n🟥 🟥 🟥 🟥 🟥 REDDD"
+	analysisRed := trans.AnalyzeEordle(inputRed)
+
+	// Test 2: Standard Black squares
+	inputBlack := "🟩 ⬛ ⬛ ⬛ ⬛ GREEN\n🟨 ⬛ ⬛ ⬛ ⬛ YELLO\n⬛ ⬛ ⬛ ⬛ ⬛ REDDD"
+	analysisBlack := trans.AnalyzeEordle(inputBlack)
+
+	// Test 3: Standard White squares
+	inputWhite := "🟩 ⬜ ⬜ ⬜ ⬜ GREEN\n🟨 ⬜ ⬜ ⬜ ⬜ YELLO\n⬜ ⬜ ⬜ ⬜ ⬜ REDDD"
+	analysisWhite := trans.AnalyzeEordle(inputWhite)
+
+	if analysisRed != analysisBlack {
+		t.Errorf("Black squares analysis did not match Red squares analysis.\nRed:\n%s\nBlack:\n%s", analysisRed, analysisBlack)
+	}
+
+	if analysisRed != analysisWhite {
+		t.Errorf("White squares analysis did not match Red squares analysis.\nRed:\n%s\nWhite:\n%s", analysisRed, analysisWhite)
+	}
+
+	// Verify the constraints are correctly parsed
+	if !strings.Contains(analysisRed, "Pattern: G____") {
+		t.Errorf("Expected pattern G____, got: %s", analysisRed)
+	}
+	if !strings.Contains(analysisRed, "Present: G,Y") {
+		t.Errorf("Expected present G,Y, got: %s", analysisRed)
+	}
+	if !strings.Contains(analysisRed, "Excluded: D,E,L,N,O,R") {
+		t.Errorf("Expected excluded D,E,L,N,O,R, got: %s", analysisRed)
+	}
+}
 
 func BenchmarkMarkdownToTelegramHTML(b *testing.B) {
 	text := "This is a **bold** and _italic_ text with some `code` and \r\n```\nblock\n```\n\n### Heading"


### PR DESCRIPTION
**Problem**
The Eordle solver currently only parses `🟥` as an excluded/incorrect letter square. Official Wordle results, however, use `⬛` (dark mode) or `⬜` (light mode) squares. Because of this, users pasting real Wordle results into the bot see an unhelpful response because the constraints fail to parse.

**Solution**
I updated the parser functions `parseConstraints` and `AnalyzeEordle` in `controller/translator/eordle.go` to recognize `⬛` (U+2B1B) and `⬜` (U+2B1C) and map them identically to `🟥`. Added unit tests in `handlers_test.go` to ensure correctness.

**Impact**
This is a major usability win. Users can now copy-paste standard results directly from NYT Wordle without the solver silently failing or missing constraints.

**Alternatives Considered**
* Replacing `⬛` and `⬜` with `🟥` before passing the input to the solver. (Rejected: Less efficient and could cause subtle issues with other input; updating the direct parsing logic was cleaner and safer).

**Validation**
- `go test -v ./...` passes
- `go build` passes
- Tested standard red, standard black, and standard white gameboards and verified constraints parse identically.

---
*PR created automatically by Jules for task [1455982570403805589](https://jules.google.com/task/1455982570403805589) started by @MUSTAFA-A-KHAN*