### PR TITLE
🎨 Pixel: Fix Leaderboard UI rendering on mobile

### DIFF
--- a/.Jules/pixel.md
+++ b/.Jules/pixel.md
@@ -1,0 +1,3 @@
+## 2024-06-09 - Avoid Preformatted Tables in Telegram Mobile
+**Learning:** Fixed-width tables using `<pre>` tags render poorly on mobile Telegram clients and break alignment completely when user-equipped Unicode emojis are present in the table.
+**Action:** Use an inline, clean HTML structure like `<b>[rank]</b> [name] — [score]` and rely on emoji-based bullets for hierarchical display.

--- a/service/leaderBoardList.go
+++ b/service/leaderBoardList.go
@@ -23,9 +23,6 @@ func LeaderBoardList(client *mongo.Client, collection string, chatID int64) stri
 	rankEmojis := []string{"🥇", "🥈", "🥉"}
 
 	leaderboard := "🏆 <b>Top 10 Players Leaderboard</b> 🏆\n\n"
-	leaderboard += "<pre>"
-	leaderboard += fmt.Sprintf("%-6s | %-20s | %s\n", "Rank", "Player", "Score")
-	leaderboard += strings.Repeat("─", 38) + "\n"
 
 	for i := 0; i < limit; i++ {
 		count := idCounts[i]
@@ -59,10 +56,9 @@ func LeaderBoardList(client *mongo.Client, collection string, chatID int64) stri
 		} else {
 			rankDisplay = "⭐ " + rankDisplay
 		}
-		leaderboard += fmt.Sprintf("%-6s | %-20s | %s\n", rankDisplay, name, score)
+		leaderboard += fmt.Sprintf("<b>%s</b> %s — %s\n", rankDisplay, name, score)
 	}
 
-	leaderboard += "</pre>"
 	leaderboard += "\n✨ <b>Keep it up and aim for the top!</b> ✨\n"
 
 	return leaderboard


### PR DESCRIPTION
### 💡 What
Updated the `LeaderBoardList` function to remove fixed-width `<pre>` table tags and instead use a simple, inline HTML layout structure for displaying rankings.

### 🎯 Why
Fixed-width, code-block based tables (like those built with `fmt.Sprintf("%-20s")`) render poorly in mobile Telegram clients due to viewport limitations, frequently requiring horizontal scrolling. Furthermore, when users equip Unicode emojis to their display names, the varying byte lengths of emojis completely break the monospace alignment of the table.

### 📸 Before
```
<pre>Rank   | Player               | Score
──────────────────────────────────────
🥇     | Name 👑              | 10 🪙
</pre>
```

### ✨ After
```
<b>🥇</b> Name 👑 — 10 🪙
```

### 📱 Mobile
This change heavily improves readability on smaller screens, ensuring the leaderboard list is easy to scan, wraps text cleanly instead of breaking tabular grids, and prevents horizontal scrolling.

---
*PR created automatically by Jules for task [7684833358871401997](https://jules.google.com/task/7684833358871401997) started by @MUSTAFA-A-KHAN*