### PR TITLE
Add configurable Wordle colors

### DIFF
--- a/controller/bot.go
+++ b/controller/bot.go
@@ -688,6 +688,9 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 		buttons := tgbotapi.NewInlineKeyboardMarkup(
 			tgbotapi.NewInlineKeyboardRow(
 				tgbotapi.NewInlineKeyboardButtonData("Wordle View 🖼️", "setting_wordle_view"),
+				tgbotapi.NewInlineKeyboardButtonData("Wordle Color 🎨", "setting_wordle_color"),
+			),
+			tgbotapi.NewInlineKeyboardRow(
 				tgbotapi.NewInlineKeyboardButtonData("Scramy Letters 🔠", "setting_scramy_letters"),
 			),
 		)
@@ -806,7 +809,7 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 		// 	view.SendMessage(bot, chatID, "Please provide a message with your report. Usage: /report [your message]")
 		// }
 	case "wordle":
-		wordlebot.HandleWordleCommand(bot, chatID, message.From.FirstName)
+		wordlebot.HandleWordleCommand(bot, chatID, message.From.FirstName, client)
 		return
 	case "scramy":
 		scramybot.HandleScramyCommand(bot, chatID, message.From.FirstName)
@@ -1221,12 +1224,48 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		buttons := tgbotapi.NewInlineKeyboardMarkup(
 			tgbotapi.NewInlineKeyboardRow(
 				tgbotapi.NewInlineKeyboardButtonData("Wordle View 🖼️", "setting_wordle_view"),
+				tgbotapi.NewInlineKeyboardButtonData("Wordle Color 🎨", "setting_wordle_color"),
+			),
+			tgbotapi.NewInlineKeyboardRow(
 				tgbotapi.NewInlineKeyboardButtonData("Scramy Letters 🔠", "setting_scramy_letters"),
 			),
 		)
 		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ *Settings*\nChoose a setting to configure:")
 		editMsg.ReplyMarkup = &buttons
 		editMsg.ParseMode = tgbotapi.ModeMarkdown
+		bot.Send(editMsg)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
+		return
+	case "setting_wordle_color":
+		buttons := tgbotapi.NewInlineKeyboardMarkup(
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("Classic (🟥)", "set_wordle_color_classic"),
+			),
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("Dark Mode (⬛)", "set_wordle_color_dark"),
+				tgbotapi.NewInlineKeyboardButtonData("Light Mode (⬜)", "set_wordle_color_light"),
+			),
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("🔙 Back", "settings_main"),
+			),
+		)
+		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ **Wordle Color Setting**\nChoose the color used for missing letters:")
+		editMsg.ReplyMarkup = &buttons
+		editMsg.ParseMode = tgbotapi.ModeMarkdown
+		bot.Send(editMsg)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
+		return
+	case "setting_wordle_color_new":
+		buttons := tgbotapi.NewInlineKeyboardMarkup(
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("Classic (🟥)", "set_wordle_color_classic_new"),
+			),
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("Dark Mode (⬛)", "set_wordle_color_dark_new"),
+				tgbotapi.NewInlineKeyboardButtonData("Light Mode (⬜)", "set_wordle_color_light_new"),
+			),
+		)
+		editMsg := tgbotapi.NewEditMessageReplyMarkup(chatID, callback.Message.MessageID, buttons)
 		bot.Send(editMsg)
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
 		return
@@ -1271,6 +1310,27 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		bot.Send(editMsg)
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "View set to Image"))
 		return
+	case "set_wordle_color_classic":
+		wordlebot.UpdateWordleColor(chatID, "classic", client)
+		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "✅ Wordle color updated to **Classic** (🟥).")
+		editMsg.ParseMode = tgbotapi.ModeMarkdown
+		bot.Send(editMsg)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Color set to Classic"))
+		return
+	case "set_wordle_color_dark":
+		wordlebot.UpdateWordleColor(chatID, "dark", client)
+		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "✅ Wordle color updated to **Dark** (⬛).")
+		editMsg.ParseMode = tgbotapi.ModeMarkdown
+		bot.Send(editMsg)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Color set to Dark"))
+		return
+	case "set_wordle_color_light":
+		wordlebot.UpdateWordleColor(chatID, "light", client)
+		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "✅ Wordle color updated to **Light** (⬜).")
+		editMsg.ParseMode = tgbotapi.ModeMarkdown
+		bot.Send(editMsg)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Color set to Light"))
+		return
 	case "set_scramy_squared_new":
 		scramybot.UpdateScramyLetterView(chatID, "squared", client)
 		scramybot.RefreshActiveGameMessage(bot, chatID, callback.Message.MessageID, client)
@@ -1291,8 +1351,23 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		wordlebot.RefreshActiveGameMessage(bot, chatID, callback.Message.MessageID, client)
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "View set to Image"))
 		return
+	case "set_wordle_color_classic_new":
+		wordlebot.UpdateWordleColor(chatID, "classic", client)
+		wordlebot.RefreshActiveGameMessage(bot, chatID, callback.Message.MessageID, client)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Color set to Classic"))
+		return
+	case "set_wordle_color_dark_new":
+		wordlebot.UpdateWordleColor(chatID, "dark", client)
+		wordlebot.RefreshActiveGameMessage(bot, chatID, callback.Message.MessageID, client)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Color set to Dark"))
+		return
+	case "set_wordle_color_light_new":
+		wordlebot.UpdateWordleColor(chatID, "light", client)
+		wordlebot.RefreshActiveGameMessage(bot, chatID, callback.Message.MessageID, client)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Color set to Light"))
+		return
 	case "wordle_start":
-		wordlebot.HandleWordleCommand(bot, chatID, callback.From.FirstName)
+		wordlebot.HandleWordleCommand(bot, chatID, callback.From.FirstName, client)
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Wordle Started!"))
 		return
 	case "cancel_new_wordle":

--- a/controller/categoryBot/categoryBot.go
+++ b/controller/categoryBot/categoryBot.go
@@ -394,7 +394,7 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 				return
 			}
 		case "wordle":
-			wordlebot.HandleWordleCommand(bot, chatID, message.From.FirstName)
+			wordlebot.HandleWordleCommand(bot, chatID, message.From.FirstName, client)
 			return
 		case "scramy":
 			scramybot.HandleScramyCommand(bot, chatID, message.From.FirstName)
@@ -812,13 +812,16 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 		buttons := tgbotapi.NewInlineKeyboardMarkup(
 			tgbotapi.NewInlineKeyboardRow(
 				tgbotapi.NewInlineKeyboardButtonData("Wordle View 🖼️", "setting_wordle_view"),
+				tgbotapi.NewInlineKeyboardButtonData("Wordle Color 🎨", "setting_wordle_color"),
+			),
+			tgbotapi.NewInlineKeyboardRow(
 				tgbotapi.NewInlineKeyboardButtonData("Scramy Letters 🔠", "setting_scramy_letters"),
 			),
 		)
 		view.SendMessageWithButtons(bot, message.Chat.ID, "⚙️ **Settings**\nChoose a setting to configure:", buttons)
 		return
 	case "wordle":
-		wordlebot.HandleWordleCommand(bot, chatID, message.From.FirstName)
+		wordlebot.HandleWordleCommand(bot, chatID, message.From.FirstName, client)
 		return
 	case "scramy":
 		scramybot.HandleScramyCommand(bot, chatID, message.From.FirstName)
@@ -1434,12 +1437,48 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		buttons := tgbotapi.NewInlineKeyboardMarkup(
 			tgbotapi.NewInlineKeyboardRow(
 				tgbotapi.NewInlineKeyboardButtonData("Wordle View 🖼️", "setting_wordle_view"),
+				tgbotapi.NewInlineKeyboardButtonData("Wordle Color 🎨", "setting_wordle_color"),
+			),
+			tgbotapi.NewInlineKeyboardRow(
 				tgbotapi.NewInlineKeyboardButtonData("Scramy Letters 🔠", "setting_scramy_letters"),
 			),
 		)
 		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ *Settings*\nChoose a setting to configure:")
 		editMsg.ReplyMarkup = &buttons
 		editMsg.ParseMode = tgbotapi.ModeMarkdown
+		bot.Send(editMsg)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
+		return
+	case "setting_wordle_color":
+		buttons := tgbotapi.NewInlineKeyboardMarkup(
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("Classic (🟥)", "set_wordle_color_classic"),
+			),
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("Dark Mode (⬛)", "set_wordle_color_dark"),
+				tgbotapi.NewInlineKeyboardButtonData("Light Mode (⬜)", "set_wordle_color_light"),
+			),
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("🔙 Back", "settings_main"),
+			),
+		)
+		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ **Wordle Color Setting**\nChoose the color used for missing letters:")
+		editMsg.ReplyMarkup = &buttons
+		editMsg.ParseMode = tgbotapi.ModeMarkdown
+		bot.Send(editMsg)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
+		return
+	case "setting_wordle_color_new":
+		buttons := tgbotapi.NewInlineKeyboardMarkup(
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("Classic (🟥)", "set_wordle_color_classic_new"),
+			),
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("Dark Mode (⬛)", "set_wordle_color_dark_new"),
+				tgbotapi.NewInlineKeyboardButtonData("Light Mode (⬜)", "set_wordle_color_light_new"),
+			),
+		)
+		editMsg := tgbotapi.NewEditMessageReplyMarkup(chatID, callback.Message.MessageID, buttons)
 		bot.Send(editMsg)
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
 		return
@@ -1484,6 +1523,27 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		bot.Send(editMsg)
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "View set to Image"))
 		return
+	case "set_wordle_color_classic":
+		wordlebot.UpdateWordleColor(chatID, "classic", client)
+		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "✅ Wordle color updated to **Classic** (🟥).")
+		editMsg.ParseMode = tgbotapi.ModeMarkdown
+		bot.Send(editMsg)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Color set to Classic"))
+		return
+	case "set_wordle_color_dark":
+		wordlebot.UpdateWordleColor(chatID, "dark", client)
+		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "✅ Wordle color updated to **Dark** (⬛).")
+		editMsg.ParseMode = tgbotapi.ModeMarkdown
+		bot.Send(editMsg)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Color set to Dark"))
+		return
+	case "set_wordle_color_light":
+		wordlebot.UpdateWordleColor(chatID, "light", client)
+		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "✅ Wordle color updated to **Light** (⬜).")
+		editMsg.ParseMode = tgbotapi.ModeMarkdown
+		bot.Send(editMsg)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Color set to Light"))
+		return
 	case "set_scramy_squared_new":
 		scramybot.UpdateScramyLetterView(chatID, "squared", client)
 		scramybot.RefreshActiveGameMessage(bot, chatID, callback.Message.MessageID, client)
@@ -1504,8 +1564,23 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		wordlebot.RefreshActiveGameMessage(bot, chatID, callback.Message.MessageID, client)
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "View set to Image"))
 		return
+	case "set_wordle_color_classic_new":
+		wordlebot.UpdateWordleColor(chatID, "classic", client)
+		wordlebot.RefreshActiveGameMessage(bot, chatID, callback.Message.MessageID, client)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Color set to Classic"))
+		return
+	case "set_wordle_color_dark_new":
+		wordlebot.UpdateWordleColor(chatID, "dark", client)
+		wordlebot.RefreshActiveGameMessage(bot, chatID, callback.Message.MessageID, client)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Color set to Dark"))
+		return
+	case "set_wordle_color_light_new":
+		wordlebot.UpdateWordleColor(chatID, "light", client)
+		wordlebot.RefreshActiveGameMessage(bot, chatID, callback.Message.MessageID, client)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Color set to Light"))
+		return
 	case "wordle_start":
-		wordlebot.HandleWordleCommand(bot, chatID, callback.From.FirstName)
+		wordlebot.HandleWordleCommand(bot, chatID, callback.From.FirstName, client)
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Wordle Started!"))
 		return
 	case "cancel_new_wordle":

--- a/controller/wordlebot/image_generator/generator.go
+++ b/controller/wordlebot/image_generator/generator.go
@@ -15,7 +15,7 @@ import (
 )
 
 // GenerateWordleImage creates an image from Wordle guesses and their feedback
-func GenerateWordleImage(guesses []string, targetWord string) ([]byte, error) {
+func GenerateWordleImage(guesses []string, targetWord string, colorConfig string) ([]byte, error) {
 	// Constants
 	cellSize := 60
 	margin := 10
@@ -42,6 +42,14 @@ func GenerateWordleImage(guesses []string, targetWord string) ([]byte, error) {
 	greenColor := color.RGBA{83, 141, 78, 255}
 	yellowColor := color.RGBA{181, 159, 59, 255}
 	redColor := color.RGBA{220, 53, 69, 255}
+
+	missColor := redColor
+	if colorConfig == "dark" {
+		missColor = color.RGBA{58, 58, 60, 255} // Dark gray (same as empty cell in classic)
+	} else if colorConfig == "light" {
+		missColor = color.RGBA{240, 240, 240, 255} // Light gray/white
+	}
+
 	textColor := color.RGBA{255, 255, 255, 255}
 
 	// Fill background
@@ -105,7 +113,7 @@ func GenerateWordleImage(guesses []string, targetWord string) ([]byte, error) {
 				}
 
 				if !foundYellow {
-					colors[c] = redColor
+					colors[c] = missColor
 				}
 			}
 		}
@@ -134,9 +142,14 @@ func GenerateWordleImage(guesses []string, targetWord string) ([]byte, error) {
 
 			// Draw text
 			if char != 0 {
+				cellTextColor := textColor
+				if colors[c] == missColor && colorConfig == "light" {
+					cellTextColor = color.RGBA{0, 0, 0, 255} // Black text for light mode miss cells
+				}
+
 				d := &font.Drawer{
 					Dst:  img,
-					Src:  image.NewUniform(textColor),
+					Src:  image.NewUniform(cellTextColor),
 					Face: face,
 				}
 

--- a/controller/wordlebot/refresh.go
+++ b/controller/wordlebot/refresh.go
@@ -28,7 +28,7 @@ func RefreshActiveGameMessage(bot *tgbotapi.BotAPI, chatID int64, messageID int,
 	)
 
 	if isImage {
-		imageData, err := image_generator.GenerateWordleImage(ws.Guesses, ws.Word)
+		imageData, err := image_generator.GenerateWordleImage(ws.Guesses, ws.Word, settings.WordleColor)
 		if err == nil {
 			err = view.EditMessageMediaWithStyledButtons(bot.Token, chatID, messageID, imageData, "wordle.png", &buttons)
 			if err != nil {
@@ -49,7 +49,7 @@ func RefreshActiveGameMessage(bot *tgbotapi.BotAPI, chatID int64, messageID int,
 	deleteMsg := tgbotapi.NewDeleteMessage(chatID, messageID)
 	bot.Send(deleteMsg)
 
-	boardStr := buildWordleBoard(ws)
+	boardStr := buildWordleBoard(ws, settings.WordleColor)
 	msgText := fmt.Sprintf("📝 *WORDLE*\n\n%s\n\nTotal: %d/6", boardStr, len(ws.Guesses))
 	msg := tgbotapi.NewMessage(chatID, msgText)
 	msg.ReplyMarkup = buttons

--- a/controller/wordlebot/settings.go
+++ b/controller/wordlebot/settings.go
@@ -13,6 +13,7 @@ import (
 type ChatSettings struct {
 	ChatID         int64  `bson:"_id"`
 	WordleViewType string `bson:"wordle_view_type"` // "text" or "image"
+	WordleColor    string `bson:"wordle_color"`     // "classic", "dark", or "light"
 }
 
 var (
@@ -32,7 +33,8 @@ func GetChatSettings(chatID int64, client *mongo.Client) *ChatSettings {
 	// Default settings
 	settings = &ChatSettings{
 		ChatID:         chatID,
-		WordleViewType: "text", // Default to text
+		WordleViewType: "text",    // Default to text
+		WordleColor:    "classic", // Default to classic
 	}
 
 	if client != nil {
@@ -68,6 +70,27 @@ func UpdateWordleViewType(chatID int64, viewType string, client *mongo.Client) e
 
 		opts := options.Update().SetUpsert(true)
 		update := bson.M{"$set": bson.M{"wordle_view_type": viewType}}
+		_, err := collection.UpdateOne(ctx, bson.M{"_id": chatID}, update, opts)
+		return err
+	}
+	return nil
+}
+
+func UpdateWordleColor(chatID int64, color string, client *mongo.Client) error {
+	settings := GetChatSettings(chatID, client)
+
+	settingsMutex.Lock()
+	settings.WordleColor = color
+	settingsCache[chatID] = settings
+	settingsMutex.Unlock()
+
+	if client != nil {
+		collection := client.Database("TelegramBot").Collection("ChatSettings")
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		opts := options.Update().SetUpsert(true)
+		update := bson.M{"$set": bson.M{"wordle_color": color}}
 		_, err := collection.UpdateOne(ctx, bson.M{"_id": chatID}, update, opts)
 		return err
 	}

--- a/controller/wordlebot/wordlebot.go
+++ b/controller/wordlebot/wordlebot.go
@@ -205,17 +205,24 @@ func getRandomWordleWord() string {
 }
 
 // validateWordleGuess compares a guess against the target word and returns colored emojis
-func validateWordleGuess(guess, target string) string {
+func validateWordleGuess(guess, target string, colorConfig string) string {
 	guess = strings.ToLower(guess)
 	target = strings.ToLower(target)
 
 	result := make([]string, 5)
 	targetCounts := make(map[rune]int)
 
+	missColor := "🟥"
+	if colorConfig == "dark" {
+		missColor = "⬛"
+	} else if colorConfig == "light" {
+		missColor = "⬜"
+	}
+
 	// First pass: count characters in target and check for exact matches (Green)
 	for i, ch := range target {
 		targetCounts[ch]++
-		result[i] = "🟥" // Default to Red
+		result[i] = missColor // Default to selected miss color
 	}
 
 	// Mark Green
@@ -256,10 +263,10 @@ func getSuperscript(num int) string {
 }
 
 // buildWordleBoard generates the string representation of the current Wordle board
-func buildWordleBoard(ws *WordleState) string {
+func buildWordleBoard(ws *WordleState, colorConfig string) string {
 	var sb strings.Builder
 	for i, guess := range ws.Guesses {
-		feedback := validateWordleGuess(guess, ws.Word)
+		feedback := validateWordleGuess(guess, ws.Word, colorConfig)
 		if i > 10 {
 			attemptNum := getSuperscript(i + 1)
 			sb.WriteString(fmt.Sprintf("%s  %s %s\n", feedback, strings.ToUpper(guess), attemptNum))
@@ -279,7 +286,7 @@ func IsWordleActive(chatID int64) bool {
 }
 
 // HandleWordleCommand starts a new Wordle game
-func HandleWordleCommand(bot *tgbotapi.BotAPI, chatID int64, username string) {
+func HandleWordleCommand(bot *tgbotapi.BotAPI, chatID int64, username string, client *mongo.Client) {
 	ws := GetOrCreateWordleState(chatID)
 
 	ws.Lock()
@@ -332,10 +339,19 @@ func HandleWordleCommand(bot *tgbotapi.BotAPI, chatID int64, username string) {
 				buttons := tgbotapi.NewInlineKeyboardMarkup(
 					tgbotapi.NewInlineKeyboardRow(
 						tgbotapi.NewInlineKeyboardButtonData("Change Layout ⚙️", "setting_wordle_view_new"),
+						tgbotapi.NewInlineKeyboardButtonData("Wordle Color 🎨", "setting_wordle_color_new"),
 					),
 				)
 
-				msg := fmt.Sprintf("🐊 🖼 *Wordle started!* ✨\n\n• The word consists of 5 letters.\n• You have %d attempts.\n\n💡 Hints:\n🟩 Correct letter in the right spot\n🟨 Correct letter but in the wrong spot\n🟥 Letter is not in the word\n\nSend a 5-letter word to guess.", ws.MaxAttempts)
+				settings := GetChatSettings(chatID, client)
+				missEmoji := "🟥"
+				if settings.WordleColor == "dark" {
+					missEmoji = "⬛"
+				} else if settings.WordleColor == "light" {
+					missEmoji = "⬜"
+				}
+
+				msg := fmt.Sprintf("🐊 🖼 *Wordle started!* ✨\n\n• The word consists of 5 letters.\n• You have %d attempts.\n\n💡 Hints:\n🟩 Correct letter in the right spot\n🟨 Correct letter but in the wrong spot\n%s Letter is not in the word\n\nSend a 5-letter word to guess.", ws.MaxAttempts, missEmoji)
 				view.SendMessageWithButtons(bot, chatID, msg, buttons)
 			case <-ws.CancelChan:
 				// Cancelled by a user
@@ -358,10 +374,19 @@ func HandleWordleCommand(bot *tgbotapi.BotAPI, chatID int64, username string) {
 	buttons := tgbotapi.NewInlineKeyboardMarkup(
 		tgbotapi.NewInlineKeyboardRow(
 			tgbotapi.NewInlineKeyboardButtonData("Change Layout ⚙️", "setting_wordle_view_new"),
+			tgbotapi.NewInlineKeyboardButtonData("Wordle Color 🎨", "setting_wordle_color_new"),
 		),
 	)
 
-	msg := fmt.Sprintf("🐊 🖼 *Wordle started!* ✨\n\n• The word consists of 5 letters.\n• You have %d attempts.\n\n💡 Hints:\n🟩 Correct letter in the right spot\n🟨 Correct letter but in the wrong spot\n🟥 Letter is not in the word\n\nSend a 5-letter word to guess.", ws.MaxAttempts)
+	settings := GetChatSettings(chatID, client)
+	missEmoji := "🟥"
+	if settings.WordleColor == "dark" {
+		missEmoji = "⬛"
+	} else if settings.WordleColor == "light" {
+		missEmoji = "⬜"
+	}
+
+	msg := fmt.Sprintf("🐊 🖼 *Wordle started!* ✨\n\n• The word consists of 5 letters.\n• You have %d attempts.\n\n💡 Hints:\n🟩 Correct letter in the right spot\n🟨 Correct letter but in the wrong spot\n%s Letter is not in the word\n\nSend a 5-letter word to guess.", ws.MaxAttempts, missEmoji)
 	view.SendMessageWithButtons(bot, chatID, msg, buttons)
 }
 
@@ -445,14 +470,14 @@ func HandleGuess(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mongo.
 
 	if isImage {
 		var err error
-		imgData, err = image_generator.GenerateWordleImage(ws.Guesses, ws.Word)
+		imgData, err = image_generator.GenerateWordleImage(ws.Guesses, ws.Word, settings.WordleColor)
 		if err != nil {
 			log.Printf("Failed to generate wordle image: %v", err)
 			isImage = false
-			board = buildWordleBoard(ws)
+			board = buildWordleBoard(ws, settings.WordleColor)
 		}
 	} else {
-		board = buildWordleBoard(ws)
+		board = buildWordleBoard(ws, settings.WordleColor)
 	}
 
 	if guess == ws.Word {


### PR DESCRIPTION
Implemented a new feature allowing users to customize the color of missed/empty letters in Wordle. They can choose between Classic (🟥), Dark Mode (⬛), or Light Mode (⬜) which applies to both text format and the dynamically generated image format.

---
*PR created automatically by Jules for task [16376956774856128470](https://jules.google.com/task/16376956774856128470) started by @MUSTAFA-A-KHAN*