### PR TITLE
🎨 Palette: Add Back buttons to game settings sub-menus

### DIFF
--- a/controller/bot.go
+++ b/controller/bot.go
@@ -1174,6 +1174,9 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 				tgbotapi.NewInlineKeyboardButtonData("Squared 🔠", "set_scramy_squared_new"),
 				tgbotapi.NewInlineKeyboardButtonData("Normal abc", "set_scramy_normal_new"),
 			),
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("🔙 Back", "refresh_scramy_game"),
+			),
 		)
 		editMsg := tgbotapi.NewEditMessageReplyMarkup(chatID, callback.Message.MessageID, buttons)
 		bot.Send(editMsg)
@@ -1264,6 +1267,9 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 				tgbotapi.NewInlineKeyboardButtonData("Dark Mode (⬛)", "set_wordle_color_dark_new"),
 				tgbotapi.NewInlineKeyboardButtonData("Light Mode (⬜)", "set_wordle_color_light_new"),
 			),
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("🔙 Back", "refresh_wordle_game"),
+			),
 		)
 		editMsg := tgbotapi.NewEditMessageReplyMarkup(chatID, callback.Message.MessageID, buttons)
 		bot.Send(editMsg)
@@ -1285,11 +1291,22 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		bot.Send(editMsg)
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
 		return
+	case "refresh_wordle_game":
+		wordlebot.RefreshActiveGameMessage(bot, chatID, callback.Message.MessageID, client)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
+		return
+	case "refresh_scramy_game":
+		scramybot.RefreshActiveGameMessage(bot, chatID, callback.Message.MessageID, client)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
+		return
 	case "setting_wordle_view_new":
 		buttons := tgbotapi.NewInlineKeyboardMarkup(
 			tgbotapi.NewInlineKeyboardRow(
 				tgbotapi.NewInlineKeyboardButtonData("Text View 📝", "set_wordle_view_text_new"),
 				tgbotapi.NewInlineKeyboardButtonData("Image View 🖼️", "set_wordle_view_image_new"),
+			),
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("🔙 Back", "refresh_wordle_game"),
 			),
 		)
 		editMsg := tgbotapi.NewEditMessageReplyMarkup(chatID, callback.Message.MessageID, buttons)

--- a/controller/categoryBot/categoryBot.go
+++ b/controller/categoryBot/categoryBot.go
@@ -1349,6 +1349,9 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 				tgbotapi.NewInlineKeyboardButtonData("Squared 🔠", "set_scramy_squared_new"),
 				tgbotapi.NewInlineKeyboardButtonData("Normal abc", "set_scramy_normal_new"),
 			),
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("🔙 Back", "refresh_scramy_game"),
+			),
 		)
 		editMsg := tgbotapi.NewEditMessageReplyMarkup(chatID, callback.Message.MessageID, buttons)
 		bot.Send(editMsg)
@@ -1477,6 +1480,9 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 				tgbotapi.NewInlineKeyboardButtonData("Dark Mode (⬛)", "set_wordle_color_dark_new"),
 				tgbotapi.NewInlineKeyboardButtonData("Light Mode (⬜)", "set_wordle_color_light_new"),
 			),
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("🔙 Back", "refresh_wordle_game"),
+			),
 		)
 		editMsg := tgbotapi.NewEditMessageReplyMarkup(chatID, callback.Message.MessageID, buttons)
 		bot.Send(editMsg)
@@ -1498,11 +1504,22 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		bot.Send(editMsg)
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
 		return
+	case "refresh_wordle_game":
+		wordlebot.RefreshActiveGameMessage(bot, chatID, callback.Message.MessageID, client)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
+		return
+	case "refresh_scramy_game":
+		scramybot.RefreshActiveGameMessage(bot, chatID, callback.Message.MessageID, client)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
+		return
 	case "setting_wordle_view_new":
 		buttons := tgbotapi.NewInlineKeyboardMarkup(
 			tgbotapi.NewInlineKeyboardRow(
 				tgbotapi.NewInlineKeyboardButtonData("Text View 📝", "set_wordle_view_text_new"),
 				tgbotapi.NewInlineKeyboardButtonData("Image View 🖼️", "set_wordle_view_image_new"),
+			),
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("🔙 Back", "refresh_wordle_game"),
 			),
 		)
 		editMsg := tgbotapi.NewEditMessageReplyMarkup(chatID, callback.Message.MessageID, buttons)


### PR DESCRIPTION
🎨 **Palette**: Add Back buttons to game settings sub-menus

**What:** Added a "🔙 Back" button to the Wordle view/color and Scramy letter layout settings sub-menus that return the user back to the active game context.
**Why:** When users access layout settings from an active game, they are left stranded in the sub-menu if they change their mind. Providing a Back button allows them to gracefully return to the game instead of abandoning the menu structure entirely.
**Accessibility:** Ensures a seamless flow and less frustrating user experience by giving users a way out.

---
*PR created automatically by Jules for task [4699802418495788698](https://jules.google.com/task/4699802418495788698) started by @MUSTAFA-A-KHAN*