### PR TITLE
feat: generate dynamic collectible cards on pack open

### DIFF
--- a/controller/collectible/collectible_controller.go
+++ b/controller/collectible/collectible_controller.go
@@ -14,6 +14,7 @@ import (
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/view"
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
 	"go.mongodb.org/mongo-driver/mongo"
+	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/service"
 )
 
 var pendingMarketplaceListing = make(map[int64]string) // map[userID]itemID
@@ -100,13 +101,26 @@ func handleBuyPack(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery, clien
 	)
 
 	if template.ImageURL != "" {
-		photo := tgbotapi.NewPhotoShare(callback.Message.Chat.ID, template.ImageURL)
-		photo.Caption = text
-		photo.ParseMode = "Markdown"
-		photo.ReplyMarkup = markup
-		_, err := bot.Send(photo)
-		if err != nil {
-			log.Printf("send error: %v", err)
+		imgBytes, err := service.GenerateCollectibleImage(item, template, callback.From.FirstName)
+		if err == nil {
+			photo := tgbotapi.NewPhotoUpload(callback.Message.Chat.ID, tgbotapi.FileBytes{Name: "card.png", Bytes: imgBytes})
+			photo.Caption = text
+			photo.ParseMode = "Markdown"
+			photo.ReplyMarkup = markup
+			_, err = bot.Send(photo)
+			if err != nil {
+				log.Printf("send photo error: %v", err)
+			}
+		} else {
+			log.Printf("image generation error: %v, falling back to url", err)
+			photo := tgbotapi.NewPhotoShare(callback.Message.Chat.ID, template.ImageURL)
+			photo.Caption = text
+			photo.ParseMode = "Markdown"
+			photo.ReplyMarkup = markup
+			_, err := bot.Send(photo)
+			if err != nil {
+				log.Printf("send error: %v", err)
+			}
 		}
 	} else {
 		view.SendMessageWithButtons(bot, callback.Message.Chat.ID, text, markup)

--- a/controller/collectible/collectible_controller.go
+++ b/controller/collectible/collectible_controller.go
@@ -101,7 +101,7 @@ func handleBuyPack(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery, clien
 	)
 
 	if template.ImageURL != "" {
-		imgBytes, err := service.GenerateCollectibleImage(item, template, callback.From.FirstName)
+		imgBytes, err := service.GenerateCollectibleImage(bot, item, template, callback.From.FirstName)
 		if err == nil {
 			photo := tgbotapi.NewPhotoUpload(callback.Message.Chat.ID, tgbotapi.FileBytes{Name: "card.png", Bytes: imgBytes})
 			photo.Caption = text

--- a/service/image_generator.go
+++ b/service/image_generator.go
@@ -7,6 +7,12 @@ import (
 	"log"
 	"strings"
 
+	"image"
+	_ "image/jpeg"
+	_ "image/png"
+	"net/http"
+
+	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/model/collectible"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/repository"
 	"github.com/fogleman/gg"
 	"github.com/golang/freetype/truetype"
@@ -169,6 +175,97 @@ func GenerateLeaderboardImage(client *mongo.Client, collection string, chatID in
 	err = dc.EncodePNG(buf)
 	if err != nil {
 		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// GenerateCollectibleImage fetches the background image from template.ImageURL
+// and overlays the serial number and owner name.
+func GenerateCollectibleImage(item collectible.Item, template collectible.Template, ownerName string) ([]byte, error) {
+	if template.ImageURL == "" {
+		return nil, fmt.Errorf("no image URL provided in template")
+	}
+
+	// 1. Fetch the background image
+	resp, err := http.Get(template.ImageURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch image: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch image, status: %d", resp.StatusCode)
+	}
+
+	bgImage, _, err := image.Decode(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode image: %w", err)
+	}
+
+	bounds := bgImage.Bounds()
+	width := bounds.Dx()
+	height := bounds.Dy()
+
+	dc := gg.NewContext(width, height)
+	dc.DrawImage(bgImage, 0, 0)
+
+	// Load font for overlay text
+	fontBold, err := truetype.Parse(gobold.TTF)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse font: %w", err)
+	}
+
+	// Calculate dynamic font size based on image height (e.g. 5% of height)
+	fontSize := float64(height) * 0.05
+	if fontSize < 20 {
+		fontSize = 20
+	}
+	faceBold := truetype.NewFace(fontBold, &truetype.Options{Size: fontSize})
+	dc.SetFontFace(faceBold)
+
+	// Draw Serial Number overlay (Top Left)
+	serialText := fmt.Sprintf("#%d", item.SerialNumber)
+
+	// Draw background box for serial number
+	w, h := dc.MeasureString(serialText)
+	paddingX := float64(width) * 0.02
+	paddingY := float64(height) * 0.02
+
+	rectWidth := w + paddingX*2
+	rectHeight := h + paddingY*2
+
+	// Orange/Gold Box for Serial Number
+	dc.SetColor(color.RGBA{R: 245, G: 166, B: 35, A: 230})
+	// Try to draw it with a rounded rectangle if gg supports it easily, otherwise standard
+	dc.DrawRoundedRectangle(0, 0, rectWidth, rectHeight, rectHeight*0.2)
+	dc.Fill()
+
+	// Text for serial number
+	dc.SetColor(color.RGBA{R: 0, G: 0, B: 0, A: 255})
+	dc.DrawStringAnchored(serialText, rectWidth/2, rectHeight/2, 0.5, 0.5)
+
+	// Draw Owner Name overlay (Bottom Left)
+	ownerText := fmt.Sprintf("Owner: %s", ownerName)
+	w2, h2 := dc.MeasureString(ownerText)
+
+	rectWidth2 := w2 + paddingX*2
+	rectHeight2 := h2 + paddingY*2
+
+	boxY := float64(height) - rectHeight2
+
+	// Dark semi-transparent box for owner
+	dc.SetColor(color.RGBA{R: 0, G: 0, B: 0, A: 180})
+	dc.DrawRoundedRectangle(0, boxY, rectWidth2, rectHeight2, rectHeight2*0.2)
+	dc.Fill()
+
+	// Text for owner
+	dc.SetColor(color.White)
+	dc.DrawStringAnchored(ownerText, rectWidth2/2, boxY + rectHeight2/2, 0.5, 0.5)
+
+	buf := new(bytes.Buffer)
+	if err := dc.EncodePNG(buf); err != nil {
+		return nil, fmt.Errorf("failed to encode resulting image: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/service/image_generator.go
+++ b/service/image_generator.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/model/collectible"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/repository"
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
 	"github.com/fogleman/gg"
 	"github.com/golang/freetype/truetype"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -180,15 +181,21 @@ func GenerateLeaderboardImage(client *mongo.Client, collection string, chatID in
 	return buf.Bytes(), nil
 }
 
-// GenerateCollectibleImage fetches the background image from template.ImageURL
+// GenerateCollectibleImage fetches the background image from template.ImageURL (which is a Telegram file_id)
 // and overlays the serial number and owner name.
-func GenerateCollectibleImage(item collectible.Item, template collectible.Template, ownerName string) ([]byte, error) {
+func GenerateCollectibleImage(bot *tgbotapi.BotAPI, item collectible.Item, template collectible.Template, ownerName string) ([]byte, error) {
 	if template.ImageURL == "" {
-		return nil, fmt.Errorf("no image URL provided in template")
+		return nil, fmt.Errorf("no image URL (file_id) provided in template")
 	}
 
-	// 1. Fetch the background image
-	resp, err := http.Get(template.ImageURL)
+	// 1. Resolve the file_id to a direct download URL
+	directURL, err := bot.GetFileDirectURL(template.ImageURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get direct file url from telegram: %w", err)
+	}
+
+	// 2. Fetch the background image
+	resp, err := http.Get(directURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch image: %w", err)
 	}

--- a/service/image_generator.go
+++ b/service/image_generator.go
@@ -270,6 +270,39 @@ func GenerateCollectibleImage(bot *tgbotapi.BotAPI, item collectible.Item, templ
 	dc.SetColor(color.White)
 	dc.DrawStringAnchored(ownerText, rectWidth2/2, boxY + rectHeight2/2, 0.5, 0.5)
 
+	// Draw Rarity overlay (Bottom Right)
+	rarityText := string(template.Rarity)
+	w3, h3 := dc.MeasureString(rarityText)
+
+	rectWidth3 := w3 + paddingX*2
+	rectHeight3 := h3 + paddingY*2
+
+	rarityBoxX := float64(width) - rectWidth3
+	rarityBoxY := float64(height) - rectHeight3
+
+	// Blue/Dark box for Rarity
+	dc.SetColor(color.RGBA{R: 20, G: 30, B: 60, A: 200})
+	dc.DrawRoundedRectangle(rarityBoxX, rarityBoxY, rectWidth3, rectHeight3, rectHeight3*0.2)
+	dc.Fill()
+
+	// Try to match color based on Rarity, default to White
+	var rarityColor color.Color = color.White
+	switch template.Rarity {
+	case collectible.RarityCommon:
+		rarityColor = color.RGBA{R: 200, G: 200, B: 200, A: 255} // Gray
+	case collectible.RarityUncommon:
+		rarityColor = color.RGBA{R: 50, G: 205, B: 50, A: 255} // Green
+	case collectible.RarityRare:
+		rarityColor = color.RGBA{R: 30, G: 144, B: 255, A: 255} // Blue
+	case collectible.RarityEpic:
+		rarityColor = color.RGBA{R: 138, G: 43, B: 226, A: 255} // Purple
+	case collectible.RarityLegendary:
+		rarityColor = color.RGBA{R: 255, G: 215, B: 0, A: 255} // Gold
+	}
+
+	dc.SetColor(rarityColor)
+	dc.DrawStringAnchored(rarityText, rarityBoxX + rectWidth3/2, rarityBoxY + rectHeight3/2, 0.5, 0.5)
+
 	buf := new(bytes.Buffer)
 	if err := dc.EncodePNG(buf); err != nil {
 		return nil, fmt.Errorf("failed to encode resulting image: %w", err)


### PR DESCRIPTION
This submission adds dynamic image generation for Collectible Packs. When a user opens a new pack, instead of just sending the raw `Template.ImageURL`, the system now pulls down that image in memory, creates an overlay for the `item.SerialNumber` and the owner's Telegram name via `fogleman/gg`, and uploads the final personalized `card.png` back to the user. It cleanly falls back to the old method if an external image fetch fails.

---
*PR created automatically by Jules for task [8091957787121357206](https://jules.google.com/task/8091957787121357206) started by @MUSTAFA-A-KHAN*