### PR TITLE
feat: add /collectibles command to open the Collectibles Hub

### DIFF
--- a/controller/bot.go
+++ b/controller/bot.go
@@ -383,6 +383,19 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 		case "leaderstatsglobal":
 			result := service.LeaderBoardList(client, "CrocEnLeader", 0)
 			view.SendMessagehtml(bot, message.Chat.ID, result)
+		case "collectibles":
+			if message.Chat.IsPrivate() {
+				collectibleController.ShowHub(bot, message.Chat.ID, message.From.ID, client)
+			} else {
+				botUsername := bot.Self.UserName
+				link := fmt.Sprintf("https://t.me/%s?start=collectibles", botUsername)
+				markup := tgbotapi.NewInlineKeyboardMarkup(
+					tgbotapi.NewInlineKeyboardRow(
+						tgbotapi.NewInlineKeyboardButtonURL("🌟 Go to Collectibles Hub", link),
+					),
+				)
+				view.SendMessageWithButtons(bot, message.Chat.ID, "Click the button below to visit the Collectibles Hub!", markup)
+			}
 		case "shop":
 			if message.Chat.IsPrivate() {
 				// Handle shop in DM
@@ -719,6 +732,19 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 	case "leaderstats":
 		result := service.LeaderBoardList(client, "CrocEnLeader", message.Chat.ID)
 		view.SendMessagehtml(bot, message.Chat.ID, result)
+	case "collectibles":
+		if message.Chat.IsPrivate() {
+			collectibleController.ShowHub(bot, message.Chat.ID, message.From.ID, client)
+		} else {
+			botUsername := bot.Self.UserName
+			link := fmt.Sprintf("https://t.me/%s?start=collectibles", botUsername)
+			markup := tgbotapi.NewInlineKeyboardMarkup(
+				tgbotapi.NewInlineKeyboardRow(
+					tgbotapi.NewInlineKeyboardButtonURL("🌟 Go to Collectibles Hub", link),
+				),
+			)
+			view.SendMessageWithButtons(bot, message.Chat.ID, "Click the button below to visit the Collectibles Hub!", markup)
+		}
 	case "shop":
 		if message.Chat.IsPrivate() {
 			// Handle shop in DM

--- a/controller/categoryBot/categoryBot.go
+++ b/controller/categoryBot/categoryBot.go
@@ -452,6 +452,19 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 		case "leaderstatsglobal":
 			result := service.LeaderBoardList(client, "CrocEnLeader", 0)
 			view.SendMessagehtml(bot, message.Chat.ID, result)
+		case "collectibles":
+			if message.Chat.IsPrivate() {
+				collectibleController.ShowHub(bot, message.Chat.ID, message.From.ID, client)
+			} else {
+				botUsername := bot.Self.UserName
+				link := fmt.Sprintf("https://t.me/%s?start=collectibles", botUsername)
+				markup := tgbotapi.NewInlineKeyboardMarkup(
+					tgbotapi.NewInlineKeyboardRow(
+						tgbotapi.NewInlineKeyboardButtonURL("🌟 Go to Collectibles Hub", link),
+					),
+				)
+				view.SendMessageWithButtons(bot, message.Chat.ID, "Click the button below to visit the Collectibles Hub!", markup)
+			}
 		case "shop":
 			if message.Chat.IsPrivate() {
 				// Handle shop in DM
@@ -851,6 +864,19 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 	case "leaderstats":
 		result := service.LeaderBoardList(client, "CrocEnLeader", message.Chat.ID)
 		view.SendMessagehtml(bot, message.Chat.ID, result)
+	case "collectibles":
+		if message.Chat.IsPrivate() {
+			collectibleController.ShowHub(bot, message.Chat.ID, message.From.ID, client)
+		} else {
+			botUsername := bot.Self.UserName
+			link := fmt.Sprintf("https://t.me/%s?start=collectibles", botUsername)
+			markup := tgbotapi.NewInlineKeyboardMarkup(
+				tgbotapi.NewInlineKeyboardRow(
+					tgbotapi.NewInlineKeyboardButtonURL("🌟 Go to Collectibles Hub", link),
+				),
+			)
+			view.SendMessageWithButtons(bot, message.Chat.ID, "Click the button below to visit the Collectibles Hub!", markup)
+		}
 	case "shop":
 		if message.Chat.IsPrivate() {
 			// Handle shop in DM


### PR DESCRIPTION
This PR adds a `/collectibles` command that functions similarly to the `/shop` command. 
It allows users to quickly access the Collectibles Hub by direct message. If invoked in a group chat, it provides a deep link redirecting the user to a direct message with the bot where the hub will be displayed. This ensures consistency in how users access hub areas across different bot contexts.

---
*PR created automatically by Jules for task [14671335447300942165](https://jules.google.com/task/14671335447300942165) started by @MUSTAFA-A-KHAN*