### PR TITLE
Add configurable text guess mode for geography game

### DIFF
--- a/controller/bot.go
+++ b/controller/bot.go
@@ -722,9 +722,20 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 			),
 			tgbotapi.NewInlineKeyboardRow(
 				tgbotapi.NewInlineKeyboardButtonData("Scramy Letters 🔠", "setting_scramy_letters"),
+				tgbotapi.NewInlineKeyboardButtonData("Geography Mode 🌍", "setting_geography_mode"),
 			),
 		)
 		view.SendMessageWithButtons(bot, message.Chat.ID, "⚙️ **Settings**\nChoose a setting to configure:", buttons)
+	case "geosettings":
+		buttons := tgbotapi.NewInlineKeyboardMarkup(
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("MCQ Mode (Multiple Choice)", "setting_geo_mode_mcq"),
+			),
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("Text Guess Mode", "setting_geo_mode_text"),
+			),
+		)
+		view.SendMessageWithButtons(bot, message.Chat.ID, "⚙️ *Geography Mode*\nChoose how you want to play Geography:\n- *MCQ Mode*: Buttons to select the answer.\n- *Text Guess Mode*: Type out your guess (5 attempts).", buttons)
 	case "stats":
 		buttons := tgbotapi.NewInlineKeyboardMarkup(tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Word Guess Group", "statsgroup_wordguess"), tgbotapi.NewInlineKeyboardButtonData("Wordle Group", "statsgroup_wordle")), tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Scramy Group", "statsgroup_scramy")))
 		view.SendMessageWithButtons(bot, chatID, "🐊🇮🇳\n📊 Choose group stats to view:", buttons)
@@ -1215,6 +1226,51 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		bot.Send(editMsg)
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
 		return
+	case "setting_geography_mode":
+		buttons := tgbotapi.NewInlineKeyboardMarkup(
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("MCQ Mode (Multiple Choice)", "setting_geo_mode_mcq"),
+			),
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("Text Guess Mode", "setting_geo_mode_text"),
+			),
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("🔙 Back", "settings_main"),
+			),
+		)
+		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ *Geography Mode*\nChoose how you want to play Geography:\n- *MCQ Mode*: Buttons to select the answer.\n- *Text Guess Mode*: Type out your guess (5 attempts).")
+		editMsg.ReplyMarkup = &buttons
+		editMsg.ParseMode = tgbotapi.ModeMarkdown
+		bot.Send(editMsg)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
+		return
+	case "setting_geo_mode_mcq", "setting_geo_mode_text":
+		mode := "mcq"
+		if callback.Data == "setting_geo_mode_text" {
+			mode = "text"
+		}
+		err := geographybot.UpdateGeographyMode(chatID, mode, client)
+		if err != nil {
+			log.Printf("Failed to update geography mode: %v", err)
+			bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Failed to update setting."))
+			return
+		}
+		modeStr := "MCQ Mode"
+		if mode == "text" {
+			modeStr = "Text Guess Mode"
+		}
+
+		buttons := tgbotapi.NewInlineKeyboardMarkup(
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("🔙 Back to Settings", "settings_main"),
+			),
+		)
+		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, fmt.Sprintf("✅ *Geography mode updated to %s!*", modeStr))
+		editMsg.ReplyMarkup = &buttons
+		editMsg.ParseMode = tgbotapi.ModeMarkdown
+		bot.Send(editMsg)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Settings saved!"))
+		return
 	case "setting_scramy_letters":
 		buttons := tgbotapi.NewInlineKeyboardMarkup(
 			tgbotapi.NewInlineKeyboardRow(
@@ -1294,6 +1350,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 			),
 			tgbotapi.NewInlineKeyboardRow(
 				tgbotapi.NewInlineKeyboardButtonData("Scramy Letters 🔠", "setting_scramy_letters"),
+				tgbotapi.NewInlineKeyboardButtonData("Geography Mode 🌍", "setting_geography_mode"),
 			),
 		)
 		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ *Settings*\nChoose a setting to configure:")

--- a/controller/categoryBot/categoryBot.go
+++ b/controller/categoryBot/categoryBot.go
@@ -850,9 +850,21 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 			),
 			tgbotapi.NewInlineKeyboardRow(
 				tgbotapi.NewInlineKeyboardButtonData("Scramy Letters 🔠", "setting_scramy_letters"),
+				tgbotapi.NewInlineKeyboardButtonData("Geography Mode 🌍", "setting_geography_mode"),
 			),
 		)
 		view.SendMessageWithButtons(bot, message.Chat.ID, "⚙️ **Settings**\nChoose a setting to configure:", buttons)
+		return
+	case "geosettings":
+		buttons := tgbotapi.NewInlineKeyboardMarkup(
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("MCQ Mode (Multiple Choice)", "setting_geo_mode_mcq"),
+			),
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("Text Guess Mode", "setting_geo_mode_text"),
+			),
+		)
+		view.SendMessageWithButtons(bot, message.Chat.ID, "⚙️ *Geography Mode*\nChoose how you want to play Geography:\n- *MCQ Mode*: Buttons to select the answer.\n- *Text Guess Mode*: Type out your guess (5 attempts).", buttons)
 		return
 	case "wordle":
 		wordlebot.HandleWordleCommand(bot, chatID, message.From.FirstName, client)
@@ -1388,6 +1400,51 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		bot.Send(editMsg)
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
 		return
+	case "setting_geography_mode":
+		buttons := tgbotapi.NewInlineKeyboardMarkup(
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("MCQ Mode (Multiple Choice)", "setting_geo_mode_mcq"),
+			),
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("Text Guess Mode", "setting_geo_mode_text"),
+			),
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("🔙 Back", "settings_main"),
+			),
+		)
+		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ *Geography Mode*\nChoose how you want to play Geography:\n- *MCQ Mode*: Buttons to select the answer.\n- *Text Guess Mode*: Type out your guess (5 attempts).")
+		editMsg.ReplyMarkup = &buttons
+		editMsg.ParseMode = tgbotapi.ModeMarkdown
+		bot.Send(editMsg)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
+		return
+	case "setting_geo_mode_mcq", "setting_geo_mode_text":
+		mode := "mcq"
+		if callback.Data == "setting_geo_mode_text" {
+			mode = "text"
+		}
+		err := geographybot.UpdateGeographyMode(chatID, mode, client)
+		if err != nil {
+			log.Printf("Failed to update geography mode: %v", err)
+			bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Failed to update setting."))
+			return
+		}
+		modeStr := "MCQ Mode"
+		if mode == "text" {
+			modeStr = "Text Guess Mode"
+		}
+
+		buttons := tgbotapi.NewInlineKeyboardMarkup(
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("🔙 Back to Settings", "settings_main"),
+			),
+		)
+		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, fmt.Sprintf("✅ *Geography mode updated to %s!*", modeStr))
+		editMsg.ReplyMarkup = &buttons
+		editMsg.ParseMode = tgbotapi.ModeMarkdown
+		bot.Send(editMsg)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Settings saved!"))
+		return
 	case "setting_scramy_letters":
 		buttons := tgbotapi.NewInlineKeyboardMarkup(
 			tgbotapi.NewInlineKeyboardRow(
@@ -1505,6 +1562,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 			),
 			tgbotapi.NewInlineKeyboardRow(
 				tgbotapi.NewInlineKeyboardButtonData("Scramy Letters 🔠", "setting_scramy_letters"),
+				tgbotapi.NewInlineKeyboardButtonData("Geography Mode 🌍", "setting_geography_mode"),
 			),
 		)
 		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ *Settings*\nChoose a setting to configure:")

--- a/controller/geographybot/geographybot.go
+++ b/controller/geographybot/geographybot.go
@@ -390,7 +390,7 @@ func startNewRound(bot *tgbotapi.BotAPI, chatID int64, client *mongo.Client) {
 		if !isTextMode {
 			view.SendMessageWithButtons(bot, chatID, question, markup)
 		} else {
-			view.SendMessage(bot, chatID, question)
+			view.SendMessageMarkdown(bot, chatID, question)
 		}
 	}
 }

--- a/controller/geographybot/geographybot.go
+++ b/controller/geographybot/geographybot.go
@@ -320,6 +320,9 @@ func startNewRound(bot *tgbotapi.BotAPI, chatID int64, client *mongo.Client) {
 	state := geographyStates[chatID]
 	geographyMutex.RUnlock()
 
+	settings := GetChatSettings(chatID, client)
+	isTextMode := settings.GeographyMode == "text"
+
 	state.Lock()
 	state.Active = true
 	state.TargetCountry = targetCountryName
@@ -327,40 +330,56 @@ func startNewRound(bot *tgbotapi.BotAPI, chatID int64, client *mongo.Client) {
 	state.QuestionType = qType
 	state.Options = options
 	state.Attempts = 0
-	state.MaxAttempts = 1 // 1 attempt for MCQ
+	if isTextMode {
+		state.MaxAttempts = 5 // 5 attempts for text mode
+	} else {
+		state.MaxAttempts = 1 // 1 attempt for MCQ
+	}
 	state.Unlock()
 
 	saveGeographyStateAsync(chatID, state)
 
-	// Send Question with Inline Buttons
-	var keyboard [][]tgbotapi.InlineKeyboardButton
-	// 2 buttons per row
-	for i := 0; i < len(options); i += 2 {
-		var row []tgbotapi.InlineKeyboardButton
-		btn1 := tgbotapi.NewInlineKeyboardButtonData(options[i], "geo_ans_"+options[i])
-		row = append(row, btn1)
-		if i+1 < len(options) {
-			btn2 := tgbotapi.NewInlineKeyboardButtonData(options[i+1], "geo_ans_"+options[i+1])
-			row = append(row, btn2)
+	// Send Question with Inline Buttons if MCQ, otherwise just text
+	var markup tgbotapi.InlineKeyboardMarkup
+	if !isTextMode {
+		var keyboard [][]tgbotapi.InlineKeyboardButton
+		// 2 buttons per row
+		for i := 0; i < len(options); i += 2 {
+			var row []tgbotapi.InlineKeyboardButton
+			btn1 := tgbotapi.NewInlineKeyboardButtonData(options[i], "geo_ans_"+options[i])
+			row = append(row, btn1)
+			if i+1 < len(options) {
+				btn2 := tgbotapi.NewInlineKeyboardButtonData(options[i+1], "geo_ans_"+options[i+1])
+				row = append(row, btn2)
+			}
+			keyboard = append(keyboard, row)
 		}
-		keyboard = append(keyboard, row)
+		markup = tgbotapi.NewInlineKeyboardMarkup(keyboard...)
 	}
-
-	markup := tgbotapi.NewInlineKeyboardMarkup(keyboard...)
 
 	if qType == "landmark" && len(targetImageBytes) > 0 {
 		photoMsg := tgbotapi.NewPhotoUpload(chatID, tgbotapi.FileBytes{Name: "landmark.jpg", Bytes: targetImageBytes})
 		photoMsg.Caption = question
 		photoMsg.ParseMode = "Markdown"
-		photoMsg.ReplyMarkup = markup
+		if !isTextMode {
+			photoMsg.ReplyMarkup = markup
+		}
 		_, err := SafeSend(bot, photoMsg, "")
 		if err != nil {
 			log.Printf("Failed to send landmark question: %v", err)
 			// Fallback to text question if image fails
-			view.SendMessageWithButtons(bot, chatID, question, markup)
+			if !isTextMode {
+				view.SendMessageWithButtons(bot, chatID, question, markup)
+			} else {
+				view.SendMessage(bot, chatID, question)
+			}
 		}
 	} else {
-		view.SendMessageWithButtons(bot, chatID, question, markup)
+		if !isTextMode {
+			view.SendMessageWithButtons(bot, chatID, question, markup)
+		} else {
+			view.SendMessage(bot, chatID, question)
+		}
 	}
 }
 
@@ -454,7 +473,29 @@ func HandleGuess(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mongo.
 
 		saveGeographyStateAsync(chatID, state)
 	} else {
-		state.Unlock()
+		settings := GetChatSettings(chatID, client)
+		if settings.GeographyMode == "text" {
+			state.Attempts++
+			if state.Attempts >= state.MaxAttempts {
+				state.Active = false
+				state.PendingNewGame = false
+				state.Unlock()
+
+				failMsg := fmt.Sprintf("❌ *Incorrect, %s!*\n\nYou've used all %d attempts.\nThe correct answer was *%s*.", message.From.FirstName, state.MaxAttempts, correctAnswer)
+				markup := tgbotapi.NewInlineKeyboardMarkup(tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Play Again 🌍", "geography_start")))
+				view.SendMessageWithButtons(bot, chatID, failMsg, markup)
+				saveGeographyStateAsync(chatID, state)
+				return
+			}
+			attemptsLeft := state.MaxAttempts - state.Attempts
+			state.Unlock()
+			saveGeographyStateAsync(chatID, state)
+
+			failMsg := fmt.Sprintf("❌ *Incorrect, %s!*\n\nAttempts left: %d", message.From.FirstName, attemptsLeft)
+			view.SendMessage(bot, chatID, failMsg)
+		} else {
+			state.Unlock()
+		}
 	}
 }
 func CancelGeography(chatID int64) bool {

--- a/controller/geographybot/geographybot.go
+++ b/controller/geographybot/geographybot.go
@@ -21,15 +21,15 @@ import (
 
 // GeographyStateDoc is the MongoDB-serializable version of GeographyState
 type GeographyStateDoc struct {
-	ChatID         int64    `bson:"_id"`
-	Active         bool     `bson:"active"`
-	QuestionType   string   `bson:"question_type"`
-	TargetCountry  string   `bson:"target_country"`
-	TargetAnswer   string   `bson:"target_answer"`
-	Options        []string `bson:"options"`
-	Attempts       int      `bson:"attempts"`
-	MaxAttempts    int      `bson:"max_attempts"`
-	PendingNewGame bool     `bson:"pending_new_game"`
+	ChatID         int64          `bson:"_id"`
+	Active         bool           `bson:"active"`
+	QuestionType   string         `bson:"question_type"`
+	TargetCountry  string         `bson:"target_country"`
+	TargetAnswer   string         `bson:"target_answer"`
+	Options        []string       `bson:"options"`
+	UserAttempts   map[string]int `bson:"user_attempts"`
+	MaxAttempts    int            `bson:"max_attempts"`
+	PendingNewGame bool           `bson:"pending_new_game"`
 }
 
 // GeographyState holds the state for a Geography game in a specific chat.
@@ -40,7 +40,7 @@ type GeographyState struct {
 	TargetCountry  string
 	TargetAnswer   string
 	Options        []string
-	Attempts       int
+	UserAttempts   map[int64]int
 	MaxAttempts    int
 	PendingNewGame bool
 	CancelChan     chan bool
@@ -54,6 +54,11 @@ var (
 // saveGeographyStateAsync asynchronously saves the Geography state to MongoDB
 func saveGeographyStateAsync(chatID int64, state *GeographyState) {
 	state.RLock()
+	userAttemptsDoc := make(map[string]int)
+	for userID, attempts := range state.UserAttempts {
+		userAttemptsDoc[fmt.Sprintf("%d", userID)] = attempts
+	}
+
 	doc := GeographyStateDoc{
 		ChatID:         chatID,
 		Active:         state.Active,
@@ -61,7 +66,7 @@ func saveGeographyStateAsync(chatID int64, state *GeographyState) {
 		TargetCountry:  state.TargetCountry,
 		TargetAnswer:   state.TargetAnswer,
 		Options:        state.Options,
-		Attempts:       state.Attempts,
+		UserAttempts:   userAttemptsDoc,
 		MaxAttempts:    state.MaxAttempts,
 		PendingNewGame: state.PendingNewGame,
 	}
@@ -88,13 +93,20 @@ func LoadSavedStates(client *mongo.Client) {
 	defer geographyMutex.Unlock()
 
 	for _, doc := range results {
+		userAttempts := make(map[int64]int)
+		for strUserID, attempts := range doc.UserAttempts {
+			var userID int64
+			fmt.Sscanf(strUserID, "%d", &userID)
+			userAttempts[userID] = attempts
+		}
+
 		gs := &GeographyState{
 			Active:         doc.Active,
 			QuestionType:   doc.QuestionType,
 			TargetCountry:  doc.TargetCountry,
 			TargetAnswer:   doc.TargetAnswer,
 			Options:        doc.Options,
-			Attempts:       doc.Attempts,
+			UserAttempts:   userAttempts,
 			MaxAttempts:    doc.MaxAttempts,
 			PendingNewGame: doc.PendingNewGame,
 			CancelChan:     make(chan bool, 1),
@@ -329,7 +341,7 @@ func startNewRound(bot *tgbotapi.BotAPI, chatID int64, client *mongo.Client) {
 	state.TargetAnswer = answer
 	state.QuestionType = qType
 	state.Options = options
-	state.Attempts = 0
+	state.UserAttempts = make(map[int64]int)
 	if isTextMode {
 		state.MaxAttempts = 5 // 5 attempts for text mode
 	} else {
@@ -457,6 +469,18 @@ func HandleGuess(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mongo.
 	}
 
 	correctAnswer := state.TargetAnswer
+
+	settings := GetChatSettings(chatID, client)
+	isTextMode := settings.GeographyMode == "text"
+	userID := int64(message.From.ID)
+
+	if isTextMode {
+		if state.UserAttempts[userID] >= state.MaxAttempts {
+			state.Unlock()
+			return // User already reached max attempts, ignore
+		}
+	}
+
 	if strings.EqualFold(strings.TrimSpace(text), correctAnswer) {
 		state.Active = false
 		state.PendingNewGame = true
@@ -473,21 +497,19 @@ func HandleGuess(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mongo.
 
 		saveGeographyStateAsync(chatID, state)
 	} else {
-		settings := GetChatSettings(chatID, client)
-		if settings.GeographyMode == "text" {
-			state.Attempts++
-			if state.Attempts >= state.MaxAttempts {
-				state.Active = false
-				state.PendingNewGame = false
-				state.Unlock()
+		if isTextMode {
+			attempts := state.UserAttempts[userID]
+			state.UserAttempts[userID] = attempts + 1
 
-				failMsg := fmt.Sprintf("❌ *Incorrect, %s!*\n\nYou've used all %d attempts.\nThe correct answer was *%s*.", message.From.FirstName, state.MaxAttempts, correctAnswer)
-				markup := tgbotapi.NewInlineKeyboardMarkup(tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Play Again 🌍", "geography_start")))
-				view.SendMessageWithButtons(bot, chatID, failMsg, markup)
+			if state.UserAttempts[userID] >= state.MaxAttempts {
+				state.Unlock()
+				failMsg := fmt.Sprintf("❌ *Incorrect, %s!*\n\nYou've used all %d attempts.", message.From.FirstName, state.MaxAttempts)
+				view.SendMessage(bot, chatID, failMsg)
 				saveGeographyStateAsync(chatID, state)
 				return
 			}
-			attemptsLeft := state.MaxAttempts - state.Attempts
+
+			attemptsLeft := state.MaxAttempts - state.UserAttempts[userID]
 			state.Unlock()
 			saveGeographyStateAsync(chatID, state)
 

--- a/controller/geographybot/settings.go
+++ b/controller/geographybot/settings.go
@@ -1,0 +1,75 @@
+package geographybot
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+type ChatSettings struct {
+	ChatID        int64  `bson:"_id"`
+	GeographyMode string `bson:"geography_mode"` // "mcq" or "text"
+}
+
+var (
+	settingsCache = make(map[int64]*ChatSettings)
+	settingsMutex sync.RWMutex
+)
+
+func GetChatSettings(chatID int64, client *mongo.Client) *ChatSettings {
+	settingsMutex.RLock()
+	settings, ok := settingsCache[chatID]
+	settingsMutex.RUnlock()
+
+	if ok {
+		return settings
+	}
+
+	// Default settings
+	settings = &ChatSettings{
+		ChatID:        chatID,
+		GeographyMode: "mcq", // Default to mcq
+	}
+
+	if client != nil {
+		collection := client.Database("TelegramBot").Collection("GeographySettings")
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		err := collection.FindOne(ctx, bson.M{"_id": chatID}).Decode(settings)
+		if err != nil && err != mongo.ErrNoDocuments {
+			// Log error if needed
+		}
+	}
+
+	settingsMutex.Lock()
+	settingsCache[chatID] = settings
+	settingsMutex.Unlock()
+
+	return settings
+}
+
+func UpdateGeographyMode(chatID int64, mode string, client *mongo.Client) error {
+	settings := GetChatSettings(chatID, client)
+
+	settingsMutex.Lock()
+	settings.GeographyMode = mode
+	settingsCache[chatID] = settings
+	settingsMutex.Unlock()
+
+	if client != nil {
+		collection := client.Database("TelegramBot").Collection("GeographySettings")
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		opts := options.Update().SetUpsert(true)
+		update := bson.M{"$set": bson.M{"geography_mode": mode}}
+		_, err := collection.UpdateOne(ctx, bson.M{"_id": chatID}, update, opts)
+		return err
+	}
+	return nil
+}

--- a/controller/geographybot/settings.go
+++ b/controller/geographybot/settings.go
@@ -26,7 +26,9 @@ func GetChatSettings(chatID int64, client *mongo.Client) *ChatSettings {
 	settingsMutex.RUnlock()
 
 	if ok {
-		return settings
+		// Return a copy to prevent data races on concurrent field reads/writes
+		copySettings := *settings
+		return &copySettings
 	}
 
 	// Default settings
@@ -47,7 +49,9 @@ func GetChatSettings(chatID int64, client *mongo.Client) *ChatSettings {
 	}
 
 	settingsMutex.Lock()
-	settingsCache[chatID] = settings
+	// Store a copy in the cache
+	cacheSettings := *settings
+	settingsCache[chatID] = &cacheSettings
 	settingsMutex.Unlock()
 
 	return settings
@@ -55,10 +59,12 @@ func GetChatSettings(chatID int64, client *mongo.Client) *ChatSettings {
 
 func UpdateGeographyMode(chatID int64, mode string, client *mongo.Client) error {
 	settings := GetChatSettings(chatID, client)
+	settings.GeographyMode = mode
 
 	settingsMutex.Lock()
-	settings.GeographyMode = mode
-	settingsCache[chatID] = settings
+	// Store a copy in the cache
+	cacheSettings := *settings
+	settingsCache[chatID] = &cacheSettings
 	settingsMutex.Unlock()
 
 	if client != nil {

--- a/view/response.go
+++ b/view/response.go
@@ -47,6 +47,12 @@ func SendMessage(bot *tgbotapi.BotAPI, chatID int64, text string) (tgbotapi.Mess
 	res, err := bot.Send(msg)
 	return res, err
 }
+func SendMessageMarkdown(bot *tgbotapi.BotAPI, chatID int64, text string) (tgbotapi.Message, error) {
+	msg := tgbotapi.NewMessage(chatID, text)
+	msg.ParseMode = tgbotapi.ModeMarkdown
+	res, err := bot.Send(msg)
+	return res, err
+}
 
 // Only works  with telegram premium accounts and the effect ID must be valid and available to the bot. If the effect ID is invalid or not available, the message will be sent without the effect.
 func SendMessageWithEffectID(bot *tgbotapi.BotAPI, chatID int64, text string, effectID string) (tgbotapi.Message, error) {


### PR DESCRIPTION
Added text guess mode to Geography game:
- Created `settings.go` in geographybot to manage settings and persist to MongoDB.
- Updated geography game logic to omit buttons and increase attempts when in "text" mode.
- Deducts attempts for incorrect answers in text mode.
- Hooked up new `/geosettings` command and updated `/settings` in both bot controllers.

---
*PR created automatically by Jules for task [6355563261041169552](https://jules.google.com/task/6355563261041169552) started by @MUSTAFA-A-KHAN*