### PR TITLE
feat: add configurable question types to Geography mode

### DIFF
--- a/controller/bot.go
+++ b/controller/bot.go
@@ -722,7 +722,7 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 			),
 			tgbotapi.NewInlineKeyboardRow(
 				tgbotapi.NewInlineKeyboardButtonData("Scramy Letters 🔠", "setting_scramy_letters"),
-				tgbotapi.NewInlineKeyboardButtonData("Geography Mode 🌍", "setting_geography_mode"),
+				tgbotapi.NewInlineKeyboardButtonData("Geography Settings 🌍", "setting_geography_main"),
 			),
 		)
 		view.SendMessageWithButtons(bot, message.Chat.ID, "⚙️ **Settings**\nChoose a setting to configure:", buttons)
@@ -1278,6 +1278,24 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		bot.Send(editMsg)
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
 		return
+	case "setting_geography_main":
+		buttons := tgbotapi.NewInlineKeyboardMarkup(
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("Mode (MCQ/Text) 🎮", "setting_geography_mode"),
+			),
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("Question Types ❓", "setting_geo_questions"),
+			),
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("🔙 Back", "settings_main"),
+			),
+		)
+		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ *Geography Settings*\nChoose a setting to configure:")
+		editMsg.ReplyMarkup = &buttons
+		editMsg.ParseMode = tgbotapi.ModeMarkdown
+		bot.Send(editMsg)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
+		return
 	case "setting_geography_mode":
 		buttons := tgbotapi.NewInlineKeyboardMarkup(
 			tgbotapi.NewInlineKeyboardRow(
@@ -1287,10 +1305,44 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 				tgbotapi.NewInlineKeyboardButtonData("Text Guess Mode", "setting_geo_mode_text"),
 			),
 			tgbotapi.NewInlineKeyboardRow(
-				tgbotapi.NewInlineKeyboardButtonData("🔙 Back", "settings_main"),
+				tgbotapi.NewInlineKeyboardButtonData("🔙 Back", "setting_geography_main"),
 			),
 		)
 		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ *Geography Mode*\nChoose how you want to play Geography:\n- *MCQ Mode*: Buttons to select the answer.\n- *Text Guess Mode*: Type out your guess (5 attempts).")
+		editMsg.ReplyMarkup = &buttons
+		editMsg.ParseMode = tgbotapi.ModeMarkdown
+		bot.Send(editMsg)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
+		return
+	case "setting_geo_questions":
+		settings := geographybot.GetChatSettings(chatID, client)
+		getBtn := func(key, label string) string {
+			if settings.QuestionTypes[key] {
+				return "✅ " + label
+			}
+			return "❌ " + label
+		}
+
+		buttons := tgbotapi.NewInlineKeyboardMarkup(
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData(getBtn("capital", "Capital"), "toggle_geo_capital"),
+				tgbotapi.NewInlineKeyboardButtonData(getBtn("flag", "Flag"), "toggle_geo_flag"),
+			),
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData(getBtn("region", "Region"), "toggle_geo_region"),
+				tgbotapi.NewInlineKeyboardButtonData(getBtn("landmark", "Landmark (Image)"), "toggle_geo_landmark"),
+			),
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData(getBtn("country_from_capital", "Country from Capital"), "toggle_geo_country_from_capital"),
+			),
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData(getBtn("landmark_name", "Landmark Name (Image)"), "toggle_geo_landmark_name"),
+			),
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("🔙 Back", "setting_geography_main"),
+			),
+		)
+		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ *Geography Question Types*\nToggle which types of questions can appear:")
 		editMsg.ReplyMarkup = &buttons
 		editMsg.ParseMode = tgbotapi.ModeMarkdown
 		bot.Send(editMsg)
@@ -1314,7 +1366,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 
 		buttons := tgbotapi.NewInlineKeyboardMarkup(
 			tgbotapi.NewInlineKeyboardRow(
-				tgbotapi.NewInlineKeyboardButtonData("🔙 Back to Settings", "settings_main"),
+				tgbotapi.NewInlineKeyboardButtonData("🔙 Back to Geography Settings", "setting_geography_main"),
 			),
 		)
 		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, fmt.Sprintf("✅ *Geography mode updated to %s!*", modeStr))
@@ -1322,6 +1374,50 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		editMsg.ParseMode = tgbotapi.ModeMarkdown
 		bot.Send(editMsg)
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Settings saved!"))
+		return
+	case "toggle_geo_capital", "toggle_geo_flag", "toggle_geo_region", "toggle_geo_landmark", "toggle_geo_country_from_capital", "toggle_geo_landmark_name":
+		qType := strings.TrimPrefix(callback.Data, "toggle_geo_")
+		err := geographybot.ToggleGeographyQuestionType(chatID, qType, client)
+		if err != nil {
+			log.Printf("Failed to toggle geography question type: %v", err)
+			bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Failed to update setting"))
+			return
+		}
+
+		// Re-render the menu
+		settings := geographybot.GetChatSettings(chatID, client)
+		getBtn := func(key, label string) string {
+			if settings.QuestionTypes[key] {
+				return "✅ " + label
+			}
+			return "❌ " + label
+		}
+
+		buttons := tgbotapi.NewInlineKeyboardMarkup(
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData(getBtn("capital", "Capital"), "toggle_geo_capital"),
+				tgbotapi.NewInlineKeyboardButtonData(getBtn("flag", "Flag"), "toggle_geo_flag"),
+			),
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData(getBtn("region", "Region"), "toggle_geo_region"),
+				tgbotapi.NewInlineKeyboardButtonData(getBtn("landmark", "Landmark (Image)"), "toggle_geo_landmark"),
+			),
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData(getBtn("country_from_capital", "Country from Capital"), "toggle_geo_country_from_capital"),
+			),
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData(getBtn("landmark_name", "Landmark Name (Image)"), "toggle_geo_landmark_name"),
+			),
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("🔙 Back", "setting_geography_main"),
+			),
+		)
+
+		// Use edit message reply markup to update the buttons in place
+		editMarkup := tgbotapi.NewEditMessageReplyMarkup(chatID, callback.Message.MessageID, buttons)
+		bot.Send(editMarkup)
+
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
 		return
 	case "setting_scramy_letters":
 		buttons := tgbotapi.NewInlineKeyboardMarkup(
@@ -1402,7 +1498,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 			),
 			tgbotapi.NewInlineKeyboardRow(
 				tgbotapi.NewInlineKeyboardButtonData("Scramy Letters 🔠", "setting_scramy_letters"),
-				tgbotapi.NewInlineKeyboardButtonData("Geography Mode 🌍", "setting_geography_mode"),
+				tgbotapi.NewInlineKeyboardButtonData("Geography Settings 🌍", "setting_geography_main"),
 			),
 		)
 		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ *Settings*\nChoose a setting to configure:")

--- a/controller/categoryBot/categoryBot.go
+++ b/controller/categoryBot/categoryBot.go
@@ -857,7 +857,7 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 			),
 			tgbotapi.NewInlineKeyboardRow(
 				tgbotapi.NewInlineKeyboardButtonData("Scramy Letters 🔠", "setting_scramy_letters"),
-				tgbotapi.NewInlineKeyboardButtonData("Geography Mode 🌍", "setting_geography_mode"),
+				tgbotapi.NewInlineKeyboardButtonData("Geography Settings 🌍", "setting_geography_main"),
 			),
 		)
 		view.SendMessageWithButtons(bot, message.Chat.ID, "⚙️ **Settings**\nChoose a setting to configure:", buttons)
@@ -1459,6 +1459,24 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		bot.Send(editMsg)
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
 		return
+	case "setting_geography_main":
+		buttons := tgbotapi.NewInlineKeyboardMarkup(
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("Mode (MCQ/Text) 🎮", "setting_geography_mode"),
+			),
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("Question Types ❓", "setting_geo_questions"),
+			),
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("🔙 Back", "settings_main"),
+			),
+		)
+		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ *Geography Settings*\nChoose a setting to configure:")
+		editMsg.ReplyMarkup = &buttons
+		editMsg.ParseMode = tgbotapi.ModeMarkdown
+		bot.Send(editMsg)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
+		return
 	case "setting_geography_mode":
 		buttons := tgbotapi.NewInlineKeyboardMarkup(
 			tgbotapi.NewInlineKeyboardRow(
@@ -1468,10 +1486,44 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 				tgbotapi.NewInlineKeyboardButtonData("Text Guess Mode", "setting_geo_mode_text"),
 			),
 			tgbotapi.NewInlineKeyboardRow(
-				tgbotapi.NewInlineKeyboardButtonData("🔙 Back", "settings_main"),
+				tgbotapi.NewInlineKeyboardButtonData("🔙 Back", "setting_geography_main"),
 			),
 		)
 		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ *Geography Mode*\nChoose how you want to play Geography:\n- *MCQ Mode*: Buttons to select the answer.\n- *Text Guess Mode*: Type out your guess (5 attempts).")
+		editMsg.ReplyMarkup = &buttons
+		editMsg.ParseMode = tgbotapi.ModeMarkdown
+		bot.Send(editMsg)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
+		return
+	case "setting_geo_questions":
+		settings := geographybot.GetChatSettings(chatID, client)
+		getBtn := func(key, label string) string {
+			if settings.QuestionTypes[key] {
+				return "✅ " + label
+			}
+			return "❌ " + label
+		}
+
+		buttons := tgbotapi.NewInlineKeyboardMarkup(
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData(getBtn("capital", "Capital"), "toggle_geo_capital"),
+				tgbotapi.NewInlineKeyboardButtonData(getBtn("flag", "Flag"), "toggle_geo_flag"),
+			),
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData(getBtn("region", "Region"), "toggle_geo_region"),
+				tgbotapi.NewInlineKeyboardButtonData(getBtn("landmark", "Landmark (Image)"), "toggle_geo_landmark"),
+			),
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData(getBtn("country_from_capital", "Country from Capital"), "toggle_geo_country_from_capital"),
+			),
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData(getBtn("landmark_name", "Landmark Name (Image)"), "toggle_geo_landmark_name"),
+			),
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("🔙 Back", "setting_geography_main"),
+			),
+		)
+		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ *Geography Question Types*\nToggle which types of questions can appear:")
 		editMsg.ReplyMarkup = &buttons
 		editMsg.ParseMode = tgbotapi.ModeMarkdown
 		bot.Send(editMsg)
@@ -1495,7 +1547,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 
 		buttons := tgbotapi.NewInlineKeyboardMarkup(
 			tgbotapi.NewInlineKeyboardRow(
-				tgbotapi.NewInlineKeyboardButtonData("🔙 Back to Settings", "settings_main"),
+				tgbotapi.NewInlineKeyboardButtonData("🔙 Back to Geography Settings", "setting_geography_main"),
 			),
 		)
 		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, fmt.Sprintf("✅ *Geography mode updated to %s!*", modeStr))
@@ -1503,6 +1555,50 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		editMsg.ParseMode = tgbotapi.ModeMarkdown
 		bot.Send(editMsg)
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Settings saved!"))
+		return
+	case "toggle_geo_capital", "toggle_geo_flag", "toggle_geo_region", "toggle_geo_landmark", "toggle_geo_country_from_capital", "toggle_geo_landmark_name":
+		qType := strings.TrimPrefix(callback.Data, "toggle_geo_")
+		err := geographybot.ToggleGeographyQuestionType(chatID, qType, client)
+		if err != nil {
+			log.Printf("Failed to toggle geography question type: %v", err)
+			bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Failed to update setting"))
+			return
+		}
+
+		// Re-render the menu
+		settings := geographybot.GetChatSettings(chatID, client)
+		getBtn := func(key, label string) string {
+			if settings.QuestionTypes[key] {
+				return "✅ " + label
+			}
+			return "❌ " + label
+		}
+
+		buttons := tgbotapi.NewInlineKeyboardMarkup(
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData(getBtn("capital", "Capital"), "toggle_geo_capital"),
+				tgbotapi.NewInlineKeyboardButtonData(getBtn("flag", "Flag"), "toggle_geo_flag"),
+			),
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData(getBtn("region", "Region"), "toggle_geo_region"),
+				tgbotapi.NewInlineKeyboardButtonData(getBtn("landmark", "Landmark (Image)"), "toggle_geo_landmark"),
+			),
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData(getBtn("country_from_capital", "Country from Capital"), "toggle_geo_country_from_capital"),
+			),
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData(getBtn("landmark_name", "Landmark Name (Image)"), "toggle_geo_landmark_name"),
+			),
+			tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("🔙 Back", "setting_geography_main"),
+			),
+		)
+
+		// Use edit message reply markup to update the buttons in place
+		editMarkup := tgbotapi.NewEditMessageReplyMarkup(chatID, callback.Message.MessageID, buttons)
+		bot.Send(editMarkup)
+
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
 		return
 	case "setting_scramy_letters":
 		buttons := tgbotapi.NewInlineKeyboardMarkup(
@@ -1621,7 +1717,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 			),
 			tgbotapi.NewInlineKeyboardRow(
 				tgbotapi.NewInlineKeyboardButtonData("Scramy Letters 🔠", "setting_scramy_letters"),
-				tgbotapi.NewInlineKeyboardButtonData("Geography Mode 🌍", "setting_geography_mode"),
+				tgbotapi.NewInlineKeyboardButtonData("Geography Settings 🌍", "setting_geography_main"),
 			),
 		)
 		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ *Settings*\nChoose a setting to configure:")

--- a/controller/geographybot/geographybot.go
+++ b/controller/geographybot/geographybot.go
@@ -225,9 +225,34 @@ func startNewRound(bot *tgbotapi.BotAPI, chatID int64, client *mongo.Client) {
 
 	rand.Seed(time.Now().UnixNano())
 
-	questionTypes := []string{"capital", "flag", "region"}
+	settings := GetChatSettings(chatID, client)
+
+	// Build active question types based on settings
+	var questionTypes []string
+	if settings.QuestionTypes == nil || settings.QuestionTypes["capital"] {
+		questionTypes = append(questionTypes, "capital")
+	}
+	if settings.QuestionTypes == nil || settings.QuestionTypes["flag"] {
+		questionTypes = append(questionTypes, "flag")
+	}
+	if settings.QuestionTypes == nil || settings.QuestionTypes["region"] {
+		questionTypes = append(questionTypes, "region")
+	}
 	if len(landmarkData) >= 4 {
-		questionTypes = append(questionTypes, "landmark")
+		if settings.QuestionTypes == nil || settings.QuestionTypes["landmark"] {
+			questionTypes = append(questionTypes, "landmark")
+		}
+		if settings.QuestionTypes == nil || settings.QuestionTypes["landmark_name"] {
+			questionTypes = append(questionTypes, "landmark_name")
+		}
+	}
+	if settings.QuestionTypes == nil || settings.QuestionTypes["country_from_capital"] {
+		questionTypes = append(questionTypes, "country_from_capital")
+	}
+
+	if len(questionTypes) == 0 {
+		view.SendMessage(bot, chatID, "No Geography question types are currently enabled in the settings. Defaulting to capitals.")
+		questionTypes = append(questionTypes, "capital")
 	}
 
 	qType := questionTypes[rand.Intn(len(questionTypes))]
@@ -239,15 +264,20 @@ func startNewRound(bot *tgbotapi.BotAPI, chatID int64, client *mongo.Client) {
 	var targetImageBytes []byte
 
 	// Pick target and generate distractors
-	if qType == "landmark" {
+	if qType == "landmark" || qType == "landmark_name" {
 		targetLandmark := landmarkData[rand.Intn(len(landmarkData))]
 		targetCountryName = targetLandmark.Country
-		answer = targetCountryName
-		question = fmt.Sprintf("🌎 *Geography Mode*\n\nWhich country is this landmark (%s) located in?", targetLandmark.Name)
+
+		if qType == "landmark" {
+			answer = targetCountryName
+			question = fmt.Sprintf("🌎 *Geography Mode*\n\nWhich country is this landmark (%s) located in?", targetLandmark.Name)
+		} else {
+			answer = targetLandmark.Name
+			question = fmt.Sprintf("🌎 *Geography Mode*\n\nWhat is the name of this landmark located in %s?", targetLandmark.Country)
+		}
 
 		// Fetch image
-		// resp, err := http.Get(targetLandmark.ImageURL)
-		client := &http.Client{}
+		httpClient := &http.Client{}
 
 		req, _ := http.NewRequest("GET", targetLandmark.ImageURL, nil)
 		req.Header.Set(
@@ -255,7 +285,7 @@ func startNewRound(bot *tgbotapi.BotAPI, chatID int64, client *mongo.Client) {
 			"CrocoRebirthBot/1.0",
 		)
 
-		resp, err := client.Do(req)
+		resp, err := httpClient.Do(req)
 
 		if err == nil {
 			defer resp.Body.Close()
@@ -266,7 +296,7 @@ func startNewRound(bot *tgbotapi.BotAPI, chatID int64, client *mongo.Client) {
 		}
 	}
 
-	if qType != "landmark" {
+	if qType != "landmark" && qType != "landmark_name" {
 		targetIndex := rand.Intn(len(countryData))
 		target := countryData[targetIndex]
 		targetCountryName = target.Name
@@ -281,26 +311,41 @@ func startNewRound(bot *tgbotapi.BotAPI, chatID int64, client *mongo.Client) {
 		case "region":
 			answer = target.Region
 			question = fmt.Sprintf("🌎 *Geography Mode*\n\nWhich region is *%s %s* located in?", target.Flag, target.Name)
+		case "country_from_capital":
+			answer = target.Name
+			question = fmt.Sprintf("🌎 *Geography Mode*\n\nWhich country's capital is *%s*?", target.Capital)
 		}
 	}
 
 	// Generate 3 random wrong options
 	wrongOptions := make([]string, 0, 3)
+
 	for len(wrongOptions) < 3 {
-		randIdx := rand.Intn(len(countryData))
-		if countryData[randIdx].Name == targetCountryName {
-			continue
-		}
 		var wOpt string
-		switch qType {
-		case "capital":
-			wOpt = countryData[randIdx].Capital
-		case "flag":
-			wOpt = countryData[randIdx].Name
-		case "region":
-			wOpt = countryData[randIdx].Region
-		case "landmark":
-			wOpt = countryData[randIdx].Name
+
+		if qType == "landmark_name" {
+			randIdx := rand.Intn(len(landmarkData))
+			if landmarkData[randIdx].Name == answer {
+				continue
+			}
+			wOpt = landmarkData[randIdx].Name
+		} else {
+			randIdx := rand.Intn(len(countryData))
+			if countryData[randIdx].Name == targetCountryName {
+				continue
+			}
+			switch qType {
+			case "capital":
+				wOpt = countryData[randIdx].Capital
+			case "flag":
+				wOpt = countryData[randIdx].Name
+			case "region":
+				wOpt = countryData[randIdx].Region
+			case "landmark":
+				wOpt = countryData[randIdx].Name
+			case "country_from_capital":
+				wOpt = countryData[randIdx].Name
+			}
 		}
 
 		if wOpt == answer {
@@ -332,7 +377,6 @@ func startNewRound(bot *tgbotapi.BotAPI, chatID int64, client *mongo.Client) {
 	state := geographyStates[chatID]
 	geographyMutex.RUnlock()
 
-	settings := GetChatSettings(chatID, client)
 	isTextMode := settings.GeographyMode == "text"
 
 	state.Lock()
@@ -369,7 +413,7 @@ func startNewRound(bot *tgbotapi.BotAPI, chatID int64, client *mongo.Client) {
 		markup = tgbotapi.NewInlineKeyboardMarkup(keyboard...)
 	}
 
-	if qType == "landmark" && len(targetImageBytes) > 0 {
+	if (qType == "landmark" || qType == "landmark_name") && len(targetImageBytes) > 0 {
 		photoMsg := tgbotapi.NewPhotoUpload(chatID, tgbotapi.FileBytes{Name: "landmark.jpg", Bytes: targetImageBytes})
 		photoMsg.Caption = question
 		photoMsg.ParseMode = "Markdown"

--- a/controller/geographybot/settings.go
+++ b/controller/geographybot/settings.go
@@ -11,8 +11,9 @@ import (
 )
 
 type ChatSettings struct {
-	ChatID        int64  `bson:"_id"`
-	GeographyMode string `bson:"geography_mode"` // "mcq" or "text"
+	ChatID        int64           `bson:"_id"`
+	GeographyMode string          `bson:"geography_mode"` // "mcq" or "text"
+	QuestionTypes map[string]bool `bson:"question_types"` // which question types are enabled
 }
 
 var (
@@ -35,6 +36,14 @@ func GetChatSettings(chatID int64, client *mongo.Client) *ChatSettings {
 	settings = &ChatSettings{
 		ChatID:        chatID,
 		GeographyMode: "mcq", // Default to mcq
+		QuestionTypes: map[string]bool{
+			"capital":              true,
+			"flag":                 true,
+			"region":               true,
+			"landmark":             true,
+			"country_from_capital": true,
+			"landmark_name":        true,
+		},
 	}
 
 	if client != nil {
@@ -46,6 +55,26 @@ func GetChatSettings(chatID int64, client *mongo.Client) *ChatSettings {
 		if err != nil && err != mongo.ErrNoDocuments {
 			// Log error if needed
 		}
+
+		// Ensure map is initialized if missing from DB
+		if settings.QuestionTypes == nil {
+			settings.QuestionTypes = map[string]bool{
+				"capital":              true,
+				"flag":                 true,
+				"region":               true,
+				"landmark":             true,
+				"country_from_capital": true,
+				"landmark_name":        true,
+			}
+		} else {
+			// Ensure new question types are added to existing DB records
+			defaults := []string{"capital", "flag", "region", "landmark", "country_from_capital", "landmark_name"}
+			for _, def := range defaults {
+				if _, exists := settings.QuestionTypes[def]; !exists {
+					settings.QuestionTypes[def] = true
+				}
+			}
+		}
 	}
 
 	settingsMutex.Lock()
@@ -55,6 +84,35 @@ func GetChatSettings(chatID int64, client *mongo.Client) *ChatSettings {
 	settingsMutex.Unlock()
 
 	return settings
+}
+
+func ToggleGeographyQuestionType(chatID int64, qType string, client *mongo.Client) error {
+	settings := GetChatSettings(chatID, client)
+
+	// Toggle value
+	if val, exists := settings.QuestionTypes[qType]; exists {
+		settings.QuestionTypes[qType] = !val
+	} else {
+		settings.QuestionTypes[qType] = true
+	}
+
+	settingsMutex.Lock()
+	// Store a copy in the cache
+	cacheSettings := *settings
+	settingsCache[chatID] = &cacheSettings
+	settingsMutex.Unlock()
+
+	if client != nil {
+		collection := client.Database("TelegramBot").Collection("GeographySettings")
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		opts := options.Update().SetUpsert(true)
+		update := bson.M{"$set": bson.M{"question_types": settings.QuestionTypes}}
+		_, err := collection.UpdateOne(ctx, bson.M{"_id": chatID}, update, opts)
+		return err
+	}
+	return nil
 }
 
 func UpdateGeographyMode(chatID int64, mode string, client *mongo.Client) error {


### PR DESCRIPTION
This PR introduces new Geography question types and makes all question types fully configurable via the bot's inline settings menu.

### Changes:
1. **New Question Types**:
   - `country_from_capital`: "Which country's capital is X?"
   - `landmark_name`: Sends a landmark image and asks for its name.
2. **Configurable Questions**: Added `QuestionTypes` boolean map to `ChatSettings` to store which questions are enabled per chat. Added migration to handle existing configurations.
3. **Unified Menu**: Refactored the Geography Settings menu into a single dedicated sub-menu containing "Mode" (MCQ/Text) and "Question Types" toggles.
4. **Consistency**: Applied UI menu changes correctly to both `bot.go` and `categoryBot.go` to ensure a uniform experience.

---
*PR created automatically by Jules for task [17339800655144431707](https://jules.google.com/task/17339800655144431707) started by @MUSTAFA-A-KHAN*