### PR TITLE
Fix broken geography images and add new landmarks

### DIFF
--- a/controller/geographybot/landmarks.json
+++ b/controller/geographybot/landmarks.json
@@ -1,22 +1,152 @@
 [
-  {"name": "Eiffel Tower", "country": "France", "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/8/85/Tour_Eiffel_Wikimedia_Commons_%28cropped%29.jpg/500px-Tour_Eiffel_Wikimedia_Commons_%28cropped%29.jpg"},
-  {"name": "Colosseum", "country": "Italy", "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/de/Colosseo_2020.jpg/500px-Colosseo_2020.jpg"},
-  {"name": "Taj Mahal", "country": "India", "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/b/bd/Taj_Mahal%2C_Agra%2C_India_edit3.jpg/500px-Taj_Mahal%2C_Agra%2C_India_edit3.jpg"},
-  {"name": "Statue of Liberty", "country": "United States", "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a1/Statue_of_Liberty_7.jpg/500px-Statue_of_Liberty_7.jpg"},
-  {"name": "Machu Picchu", "country": "Peru", "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/eb/Machu_Picchu%2C_Peru.jpg/500px-Machu_Picchu%2C_Peru.jpg"},
-  {"name": "Great Wall of China", "country": "China", "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/2/23/The_Great_Wall_of_China_at_Jinshanling-edit.jpg/500px-The_Great_Wall_of_China_at_Jinshanling-edit.jpg"},
-  {"name": "Christ the Redeemer", "country": "Brazil", "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/4f/Christ_the_Redeemer_-_Cristo_Redentor.jpg/500px-Christ_the_Redeemer_-_Cristo_Redentor.jpg"},
-  {"name": "Pyramids of Giza", "country": "Egypt", "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e3/Kheops-Pyramid.jpg/500px-Kheops-Pyramid.jpg"},
-  {"name": "Sydney Opera House", "country": "Australia", "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/40/Sydney_Opera_House_Sails.jpg/500px-Sydney_Opera_House_Sails.jpg"},
-  {"name": "Petra", "country": "Jordan", "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/Treasury_petra_crop.jpeg/500px-Treasury_petra_crop.jpeg"},
-  {"name": "Stonehenge", "country": "United Kingdom", "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3c/Stonehenge2007_07_30.jpg/500px-Stonehenge2007_07_30.jpg"},
-  {"name": "Chichen Itza", "country": "Mexico", "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/5/51/Chichen_Itza_3.jpg/500px-Chichen_Itza_3.jpg"},
-  {"name": "Acropolis of Athens", "country": "Greece", "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a7/Parthenon_from_west.jpg/500px-Parthenon_from_west.jpg"},
-  {"name": "Mount Fuji", "country": "Japan", "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/1/1b/080103_huji.jpg/500px-080103_huji.jpg"},
-  {"name": "Sagrada Familia", "country": "Spain", "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/30/SagradaFamilia_2022.jpg/500px-SagradaFamilia_2022.jpg"},
-  {"name": "Burj Khalifa", "country": "United Arab Emirates", "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c2/Burj_Khalifa_view.jpg/500px-Burj_Khalifa_view.jpg"},
-  {"name": "CN Tower", "country": "Canada", "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/9/96/Toronto_-_ON_-_Toronto_Skyline.jpg/500px-Toronto_-_ON_-_Toronto_Skyline.jpg"},
-  {"name": "St. Basil's Cathedral", "country": "Russia", "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/1/11/Moscow_July_2011-16.jpg/500px-Moscow_July_2011-16.jpg"},
-  {"name": "Angkor Wat", "country": "Cambodia", "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/41/Angkor_Wat.jpg/500px-Angkor_Wat.jpg"},
-  {"name": "Golden Gate Bridge", "country": "United States", "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0c/GoldenGateBridge-001.jpg/500px-GoldenGateBridge-001.jpg"}
+  {
+    "name": "Eiffel Tower",
+    "country": "France",
+    "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/8/85/Tour_Eiffel_Wikimedia_Commons_%28cropped%29.jpg/500px-Tour_Eiffel_Wikimedia_Commons_%28cropped%29.jpg"
+  },
+  {
+    "name": "Colosseum",
+    "country": "Italy",
+    "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/de/Colosseo_2020.jpg/500px-Colosseo_2020.jpg"
+  },
+  {
+    "name": "Taj Mahal",
+    "country": "India",
+    "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/b/bd/Taj_Mahal%2C_Agra%2C_India_edit3.jpg/500px-Taj_Mahal%2C_Agra%2C_India_edit3.jpg"
+  },
+  {
+    "name": "Statue of Liberty",
+    "country": "United States",
+    "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a1/Statue_of_Liberty_7.jpg/500px-Statue_of_Liberty_7.jpg"
+  },
+  {
+    "name": "Machu Picchu",
+    "country": "Peru",
+    "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/eb/Machu_Picchu%2C_Peru.jpg/500px-Machu_Picchu%2C_Peru.jpg"
+  },
+  {
+    "name": "Great Wall of China",
+    "country": "China",
+    "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/2/23/The_Great_Wall_of_China_at_Jinshanling-edit.jpg/500px-The_Great_Wall_of_China_at_Jinshanling-edit.jpg"
+  },
+  {
+    "name": "Christ the Redeemer",
+    "country": "Brazil",
+    "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/4f/Christ_the_Redeemer_-_Cristo_Redentor.jpg/500px-Christ_the_Redeemer_-_Cristo_Redentor.jpg"
+  },
+  {
+    "name": "Pyramids of Giza",
+    "country": "Egypt",
+    "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e3/Kheops-Pyramid.jpg/500px-Kheops-Pyramid.jpg"
+  },
+  {
+    "name": "Sydney Opera House",
+    "country": "Australia",
+    "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/40/Sydney_Opera_House_Sails.jpg/500px-Sydney_Opera_House_Sails.jpg"
+  },
+  {
+    "name": "Petra",
+    "country": "Jordan",
+    "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/Treasury_petra_crop.jpeg/500px-Treasury_petra_crop.jpeg"
+  },
+  {
+    "name": "Stonehenge",
+    "country": "United Kingdom",
+    "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3c/Stonehenge2007_07_30.jpg/500px-Stonehenge2007_07_30.jpg"
+  },
+  {
+    "name": "Chichen Itza",
+    "country": "Mexico",
+    "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/5/51/Chichen_Itza_3.jpg/500px-Chichen_Itza_3.jpg"
+  },
+  {
+    "name": "Acropolis of Athens",
+    "country": "Greece",
+    "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a7/Parthenon_from_west.jpg/500px-Parthenon_from_west.jpg"
+  },
+  {
+    "name": "Mount Fuji",
+    "country": "Japan",
+    "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/1/1b/080103_huji.jpg/500px-080103_huji.jpg"
+  },
+  {
+    "name": "Sagrada Familia",
+    "country": "Spain",
+    "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/30/SagradaFamilia_2022.jpg/500px-SagradaFamilia_2022.jpg"
+  },
+  {
+    "name": "Burj Khalifa",
+    "country": "United Arab Emirates",
+    "image_url": "https://upload.wikimedia.org/wikipedia/en/thumb/9/93/Burj_Khalifa.jpg/500px-Burj_Khalifa.jpg"
+  },
+  {
+    "name": "CN Tower",
+    "country": "Canada",
+    "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b7/CN_Tower_from_Puente_de_Luz%2C_Toronto%2C_Ontario%2C_2025-08-25_01.jpg/500px-CN_Tower_from_Puente_de_Luz%2C_Toronto%2C_Ontario%2C_2025-08-25_01.jpg"
+  },
+  {
+    "name": "St. Basil's Cathedral",
+    "country": "Russia",
+    "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/1/18/Saint_Basil%27s_Cathedral_in_Moscow.jpg/500px-Saint_Basil%27s_Cathedral_in_Moscow.jpg"
+  },
+  {
+    "name": "Angkor Wat",
+    "country": "Cambodia",
+    "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/41/Angkor_Wat.jpg/500px-Angkor_Wat.jpg"
+  },
+  {
+    "name": "Golden Gate Bridge",
+    "country": "United States",
+    "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0c/GoldenGateBridge-001.jpg/500px-GoldenGateBridge-001.jpg"
+  },
+  {
+    "name": "Mount Rushmore",
+    "country": "United States",
+    "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/8/87/Mount_Rushmore_detail_view_%28100MP%29.jpg/500px-Mount_Rushmore_detail_view_%28100MP%29.jpg"
+  },
+  {
+    "name": "Big Ben",
+    "country": "United Kingdom",
+    "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/43/Elizabeth_Tower%2C_June_2022.jpg/500px-Elizabeth_Tower%2C_June_2022.jpg"
+  },
+  {
+    "name": "Louvre",
+    "country": "France",
+    "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/66/Louvre_Museum_Wikimedia_Commons.jpg/500px-Louvre_Museum_Wikimedia_Commons.jpg"
+  },
+  {
+    "name": "Potala Palace",
+    "country": "China",
+    "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b6/Potala_Palace_HQ.jpg/500px-Potala_Palace_HQ.jpg"
+  },
+  {
+    "name": "Mount Kilimanjaro",
+    "country": "Tanzania",
+    "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/6c/Kilimanjaro_from_Amboseli.jpg/500px-Kilimanjaro_from_Amboseli.jpg"
+  },
+  {
+    "name": "Mount Everest",
+    "country": "Nepal",
+    "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/1/15/Mt._Everest_from_Gokyo_Ri_November_5%2C_2012.jpg/500px-Mt._Everest_from_Gokyo_Ri_November_5%2C_2012.jpg"
+  },
+  {
+    "name": "Victoria Falls",
+    "country": "Zambia",
+    "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/da/Cataratas_Victoria%2C_Zambia-Zimbabue%2C_2018-07-27%2C_DD_04.jpg/500px-Cataratas_Victoria%2C_Zambia-Zimbabue%2C_2018-07-27%2C_DD_04.jpg"
+  },
+  {
+    "name": "Niagara Falls",
+    "country": "Canada",
+    "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/a/ab/3Falls_Niagara.jpg/500px-3Falls_Niagara.jpg"
+  },
+  {
+    "name": "Grand Canyon",
+    "country": "United States",
+    "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/31/Canyon_River_Tree_%28165872763%29.jpeg/500px-Canyon_River_Tree_%28165872763%29.jpeg"
+  },
+  {
+    "name": "Alhambra",
+    "country": "Spain",
+    "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/de/Dawn_Charles_V_Palace_Alhambra_Granada_Andalusia_Spain.jpg/500px-Dawn_Charles_V_Palace_Alhambra_Granada_Andalusia_Spain.jpg"
+  }
 ]


### PR DESCRIPTION
This PR fixes several broken images in the geography mode's landmark data and introduces 10 new landmarks to expand the content.\n\nChanges:\n1. Replaced broken Wikimedia thumb URLs for CN Tower, St. Basil's Cathedral, and Burj Khalifa in `controller/geographybot/landmarks.json` with working URLs.\n2. Added 10 new landmarks to `landmarks.json`, including Mount Rushmore, Big Ben, Louvre, Potala Palace, Mount Kilimanjaro, Mount Everest, Victoria Falls, Niagara Falls, Grand Canyon, and Alhambra. All new image URLs have been tested and return a 200 OK status.

---
*PR created automatically by Jules for task [10578272389109348956](https://jules.google.com/task/10578272389109348956) started by @MUSTAFA-A-KHAN*