### PR TITLE
🎨 Palette: Add ForceReply to custom word prompts

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,6 @@
 
 **Action:** Ensure all multi-level inline keyboard menus have a "🔙 Back" button to smoothly return to the previous level without abandoning the menu structure entirely.
 ## 2026-06-10 - Add ForceReply to User Prompts\n**Learning:** To prompt users for specific textual input (e.g., asking for a price or value), using a standard message can be confusing. Using `tgbotapi.ForceReply{ForceReply: true}` automatically opens their keyboard and sets their message as a reply, improving the UX and clarifying intent.\n**Action:** When intercepting user input in a conversation flow, attach `ForceReply` to the prompt message to explicitly guide the user to reply.
+## $(date +%Y-%m-%d) - Add ForceReply to user input messages
+**Learning:** For interactive text-guessing interactions that requires user context, a simple message might be missed or require manual 'replying'. Adding ForceReply to the message ensures the user prompt keyboard forces the user to reply to the bot message, linking the contexts seamlessly.
+**Action:** When creating text prompts in Telegram Bots that wait for user inputs to update a specific state (like a custom word), attach `ForceReply` to the sent message using `tgbotapi.ForceReply{ForceReply: true}`.

--- a/controller/bot.go
+++ b/controller/bot.go
@@ -324,7 +324,9 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 							customWordMutex.Lock()
 							customWordState[int64(message.From.ID)] = groupChatID
 							customWordMutex.Unlock()
-							view.SendMessage(bot, chatID, "Type the word you want the group to guess (must be a valid English word):")
+							msg := tgbotapi.NewMessage(chatID, "Type the word you want the group to guess (must be a valid English word):")
+							msg.ReplyMarkup = tgbotapi.ForceReply{ForceReply: true}
+							bot.Send(msg)
 						} else {
 							view.SendMessage(bot, chatID, "You are not the current leader in that group.")
 						}

--- a/controller/categoryBot/categoryBot.go
+++ b/controller/categoryBot/categoryBot.go
@@ -387,7 +387,9 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 							customWordMutex.Lock()
 							customWordState[int64(message.From.ID)] = groupChatID
 							customWordMutex.Unlock()
-							view.SendMessage(bot, chatID, "Type the word you want the group to guess (must be a valid English word):")
+							msg := tgbotapi.NewMessage(chatID, "Type the word you want the group to guess (must be a valid English word):")
+							msg.ReplyMarkup = tgbotapi.ForceReply{ForceReply: true}
+							bot.Send(msg)
 						} else {
 							view.SendMessage(bot, chatID, "You are not the current leader in that group.")
 						}

--- a/plan.md
+++ b/plan.md
@@ -1,18 +1,11 @@
-1. **Change Command Handlers (`/statsimage` and `/statsimageglobal`)**:
-   - In `controller/bot.go` and `controller/categoryBot/categoryBot.go`:
-   - When `/statsimage` is called, instead of sending a text prompt with an inline keyboard, immediately generate the default group image (e.g. "CrocEn") and send it with the "statsimg_group" inline keyboard.
-   - When `/statsimageglobal` is called, generate the default global image ("CrocEn") and send it with the "statsimg_global" inline keyboard.
-
-2. **Change Callback Handlers**:
-   - In both files, for the `statsimg_global_*` and `statsimg_group_*` callbacks, use `tgbotapi.EditMessageMediaConfig` to update the photo of the existing message in place.
-   - The media being sent will be a `tgbotapi.NewInputMediaPhoto` wrapped around a `tgbotapi.FileBytes`.
-   - Update the message's `ReplyMarkup` alongside the media edit to preserve the buttons.
-
-3. **Verify Compilation**:
-   - Run `go build -v ./...`.
-
-4. **Pre-commit Steps**:
-   - Run verification, tests, and memory.
-
-5. **Submit**:
-   - Submit the change.
+1. **Analyze existing user prompts for Custom Word:**
+    - Currently, `controller/bot.go` and `controller/categoryBot/categoryBot.go` prompt the user for the custom word using `view.SendMessage`.
+    - This is a text interaction flow. The memory states that using `ForceReply` on messages that prompt for user input is a UX improvement because it automatically opens the keyboard and sets the message as a reply.
+2. **Update the prompts to use `ForceReply`:**
+    - I will update `controller/bot.go` where it prompts for the custom word to use `tgbotapi.ForceReply{ForceReply: true}`.
+    - I will update `controller/categoryBot/categoryBot.go` similarly.
+    - To do this, I will need to use a function like `bot.Send(msg)` directly instead of `view.SendMessage`, because `view.SendMessage` does not expose a way to set `ReplyMarkup` for `ForceReply`. This matches the implementation in `controller/collectible/collectible_controller.go`.
+3. **Execute Pre-commit Steps:**
+    - Run the pre-commit instructions using `pre_commit_instructions` tool to make sure proper testing, verifications, reviews and reflections are done.
+4. **Submit PR:**
+    - Submit the changes using the `submit` tool.


### PR DESCRIPTION
Replaced standard `view.SendMessage` text prompts for the "Custom Word" feature with `ForceReply` prompts in both `controller/bot.go` and `controller/categoryBot/categoryBot.go`. This automatically triggers the user's keyboard and forces a reply, providing a smoother, more guided UX.

---
*PR created automatically by Jules for task [17268646607668218443](https://jules.google.com/task/17268646607668218443) started by @MUSTAFA-A-KHAN*