### PR TITLE
Add geography mode hints

### DIFF
--- a/controller/bot.go
+++ b/controller/bot.go
@@ -12,6 +12,7 @@ import (
 
 	collectibleController "github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/collectible"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/geographybot"
+	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/translator"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/scramybot"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/wordlebot"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/model"
@@ -872,6 +873,9 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 		return
 	case "geography":
 		geographybot.HandleGeographyCommand(bot, chatID, message.From.FirstName, client)
+		return
+	case "geohint":
+		geographybot.HandleGeographyHint(bot, message, client, chatID, translator.NewTextTranslator())
 		return
 	case "cancelgeo":
 		if geographybot.CancelGeography(chatID) {

--- a/controller/categoryBot/categoryBot.go
+++ b/controller/categoryBot/categoryBot.go
@@ -13,6 +13,7 @@ import (
 
 	collectibleController "github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/collectible"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/geographybot"
+	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/translator"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/scramybot"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/wordlebot"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/model"
@@ -411,6 +412,9 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 			return
 		case "geography":
 			geographybot.HandleGeographyCommand(bot, chatID, message.From.FirstName, client)
+			return
+		case "geohint":
+			geographybot.HandleGeographyHint(bot, message, client, chatID, translator.NewTextTranslator())
 			return
 
 		case "cancelgeo":
@@ -884,6 +888,9 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 		return
 	case "geography":
 		geographybot.HandleGeographyCommand(bot, chatID, message.From.FirstName, client)
+		return
+	case "geohint":
+		geographybot.HandleGeographyHint(bot, message, client, chatID, translator.NewTextTranslator())
 		return
 	case "cancelgeo":
 		if geographybot.CancelGeography(chatID) {

--- a/controller/geographybot/geographybot.go
+++ b/controller/geographybot/geographybot.go
@@ -25,29 +25,33 @@ import (
 
 // GeographyStateDoc is the MongoDB-serializable version of GeographyState
 type GeographyStateDoc struct {
-	ChatID         int64          `bson:"_id"`
-	Active         bool           `bson:"active"`
-	QuestionType   string         `bson:"question_type"`
-	TargetCountry  string         `bson:"target_country"`
-	TargetAnswer   string         `bson:"target_answer"`
-	Options        []string       `bson:"options"`
-	UserAttempts   map[string]int `bson:"user_attempts"`
-	MaxAttempts    int            `bson:"max_attempts"`
-	PendingNewGame bool           `bson:"pending_new_game"`
+	ChatID            int64          `bson:"_id"`
+	Active            bool           `bson:"active"`
+	QuestionType      string         `bson:"question_type"`
+	TargetCountry     string         `bson:"target_country"`
+	TargetAnswer      string         `bson:"target_answer"`
+	Options           []string       `bson:"options"`
+	UserAttempts      map[string]int `bson:"user_attempts"`
+	MaxAttempts       int            `bson:"max_attempts"`
+	PendingNewGame    bool           `bson:"pending_new_game"`
+	LastHintTimestamp time.Time      `bson:"last_hint_timestamp"`
+	LastHintTypeSent  int            `bson:"last_hint_type_sent"`
 }
 
 // GeographyState holds the state for a Geography game in a specific chat.
 type GeographyState struct {
 	sync.RWMutex
-	Active         bool
-	QuestionType   string // "capital", "flag", "region"
-	TargetCountry  string
-	TargetAnswer   string
-	Options        []string
-	UserAttempts   map[int64]int
-	MaxAttempts    int
-	PendingNewGame bool
-	CancelChan     chan bool
+	Active            bool
+	QuestionType      string // "capital", "flag", "region"
+	TargetCountry     string
+	TargetAnswer      string
+	Options           []string
+	UserAttempts      map[int64]int
+	MaxAttempts       int
+	PendingNewGame    bool
+	CancelChan        chan bool
+	LastHintTimestamp time.Time
+	LastHintTypeSent  int
 }
 
 var (
@@ -64,15 +68,17 @@ func saveGeographyStateAsync(chatID int64, state *GeographyState) {
 	}
 
 	doc := GeographyStateDoc{
-		ChatID:         chatID,
-		Active:         state.Active,
-		QuestionType:   state.QuestionType,
-		TargetCountry:  state.TargetCountry,
-		TargetAnswer:   state.TargetAnswer,
-		Options:        state.Options,
-		UserAttempts:   userAttemptsDoc,
-		MaxAttempts:    state.MaxAttempts,
-		PendingNewGame: state.PendingNewGame,
+		ChatID:            chatID,
+		Active:            state.Active,
+		QuestionType:      state.QuestionType,
+		TargetCountry:     state.TargetCountry,
+		TargetAnswer:      state.TargetAnswer,
+		Options:           state.Options,
+		UserAttempts:      userAttemptsDoc,
+		MaxAttempts:       state.MaxAttempts,
+		PendingNewGame:    state.PendingNewGame,
+		LastHintTimestamp: state.LastHintTimestamp,
+		LastHintTypeSent:  state.LastHintTypeSent,
 	}
 	state.RUnlock()
 
@@ -105,15 +111,17 @@ func LoadSavedStates(client *mongo.Client) {
 		}
 
 		gs := &GeographyState{
-			Active:         doc.Active,
-			QuestionType:   doc.QuestionType,
-			TargetCountry:  doc.TargetCountry,
-			TargetAnswer:   doc.TargetAnswer,
-			Options:        doc.Options,
-			UserAttempts:   userAttempts,
-			MaxAttempts:    doc.MaxAttempts,
-			PendingNewGame: doc.PendingNewGame,
-			CancelChan:     make(chan bool, 1),
+			Active:            doc.Active,
+			QuestionType:      doc.QuestionType,
+			TargetCountry:     doc.TargetCountry,
+			TargetAnswer:      doc.TargetAnswer,
+			Options:           doc.Options,
+			UserAttempts:      userAttempts,
+			MaxAttempts:       doc.MaxAttempts,
+			PendingNewGame:    doc.PendingNewGame,
+			CancelChan:        make(chan bool, 1),
+			LastHintTimestamp: doc.LastHintTimestamp,
+			LastHintTypeSent:  doc.LastHintTypeSent,
 		}
 		geographyStates[doc.ChatID] = gs
 	}
@@ -744,4 +752,63 @@ func SafeSend(
 	}
 
 	return msg, fmt.Errorf("max retries exceeded")
+}
+
+// HandleGeographyHint handles user request for a hint in text mode
+func HandleGeographyHint(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mongo.Client, chatID int64, translatorService interface{ GetHintForGeography(string) string }) {
+	geographyMutex.RLock()
+	state, exists := geographyStates[chatID]
+	geographyMutex.RUnlock()
+
+	if !exists {
+		return
+	}
+
+	state.Lock()
+	if !state.Active {
+		state.Unlock()
+		return
+	}
+
+	settings := GetChatSettings(chatID, client)
+	if settings.GeographyMode != "text" {
+		state.Unlock()
+		view.SendMessage(bot, chatID, "Hints are only available in text mode.")
+		return
+	}
+
+	correctAnswer := state.TargetAnswer
+	lastHint := state.LastHintTimestamp
+	state.Unlock()
+
+	if !lastHint.IsZero() && time.Since(lastHint) < 8*time.Second {
+		view.SendMessage(bot, chatID, "Please take a moment to think before asking for another hint.")
+		return
+	}
+
+	hintMsg := tgbotapi.NewMessage(chatID, "Thinking...")
+	sentHintMsg, err := bot.Send(hintMsg)
+	if err != nil {
+		log.Printf("Failed to send thinking msg: %v", err)
+	}
+
+	// Fetch hint
+	hint := translatorService.GetHintForGeography(correctAnswer)
+
+	if hint == "something went wrong" {
+		hint = "Sorry, I couldn't generate a hint right now. 😔"
+	}
+
+	if sentHintMsg.MessageID != 0 {
+		editMsg := tgbotapi.NewEditMessageText(chatID, sentHintMsg.MessageID, hint)
+		bot.Send(editMsg)
+	} else {
+		view.SendMessage(bot, chatID, hint)
+	}
+
+	state.Lock()
+	state.LastHintTimestamp = time.Now()
+	state.Unlock()
+
+	saveGeographyStateAsync(chatID, state)
 }

--- a/controller/translator/translator.go
+++ b/controller/translator/translator.go
@@ -1357,3 +1357,64 @@ func (t *TextTranslator) ElevenLabsDyna(text string, voiceID string) string {
 	return "Audio saved successfully as output.mp3"
 
 }
+
+func (t *TextTranslator) GetHintForGeography(text string) string {
+	if OpenAIKey == "" {
+		return llmErrorMessage
+	}
+
+	url := "https://api.llm7.io/v1/chat/completions"
+
+	payload := map[string]interface{}{
+		"model": "openai/gpt-4o",
+		"messages": []map[string]string{
+			{"role": "user", "content": fmt.Sprintf("Give me a fun, short, and interesting geographical fact or clue about the following answer, without revealing the answer itself: %s", text)},
+		},
+	}
+
+	jsonData, err := json.Marshal(payload)
+	if err != nil {
+		return llmErrorMessage
+	}
+
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return llmErrorMessage
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", OpenAIKey))
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return llmErrorMessage
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return llmErrorMessage
+	}
+
+	if resp.StatusCode != 200 {
+		return llmErrorMessage
+	}
+
+	var response map[string]interface{}
+	if err := json.Unmarshal(body, &response); err != nil {
+		return llmErrorMessage
+	}
+
+	if choices, ok := response["choices"].([]interface{}); ok && len(choices) > 0 {
+		if choice, ok := choices[0].(map[string]interface{}); ok {
+			if message, ok := choice["message"].(map[string]interface{}); ok {
+				if content, ok := message["content"].(string); ok {
+					return content
+				}
+			}
+		}
+	}
+
+	return llmErrorMessage
+}


### PR DESCRIPTION
This PR implements a hint system for the geography game in text guess mode. Players can request a hint by using the `/geohint` command. The hint provides a fun or educational clue via an LLM call using the `translator.TextTranslator`, with an 8-second cooldown to prevent spam. The cooldown state is correctly mapped to both the in-memory game state and its MongoDB persistence struct.

---
*PR created automatically by Jules for task [4580748898879339126](https://jules.google.com/task/4580748898879339126) started by @MUSTAFA-A-KHAN*