### PR TITLE
Automate Daily Leaderboard JSON Export to Docs Branch

### DIFF
--- a/.github/workflows/leaderboard-sync.yml
+++ b/.github/workflows/leaderboard-sync.yml
@@ -1,0 +1,60 @@
+name: Sync Leaderboards to Docs
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # Run daily at midnight UTC
+  workflow_dispatch:     # Allow manual triggers
+
+permissions:
+  contents: write        # Required to push to the docs branch
+
+jobs:
+  export-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Fetch all history so we can checkout docs if needed
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.22.3' # Matching the version in go.yml
+
+      - name: Generate leaderboard JSON
+        run: |
+          go run cmd/export_leaderboard/main.go
+          ls -lh leaderboard.json
+
+      - name: Switch to docs branch and update
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Stash the generated file temporarily
+          mv leaderboard.json /tmp/leaderboard.json
+
+          # Check if docs branch exists locally or on origin
+          if git ls-remote --heads origin docs | grep -q docs; then
+            echo "Branch docs exists, checking it out..."
+            git checkout docs
+          else
+            echo "Branch docs does not exist, creating it as an orphan branch..."
+            git checkout --orphan docs
+            git rm -rf .
+          fi
+
+          # Restore the generated file
+          mv /tmp/leaderboard.json ./leaderboard.json
+
+          # Add and commit
+          git add leaderboard.json
+
+          # Only commit and push if there are changes
+          if ! git diff --staged --quiet; then
+            git commit -m "Update leaderboard JSON data [skip ci]"
+            git push origin docs
+          else
+            echo "No changes in leaderboard.json, skipping."
+          fi

--- a/cmd/export_leaderboard/main.go
+++ b/cmd/export_leaderboard/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/repository"
+)
+
+func main() {
+	client := repository.DbManager()
+	if client == nil {
+		log.Fatal("Could not connect to database")
+	}
+
+	collections := []string{"CrocEnLeader", "WordleEn", "ScramyEn", "GeographyPoints"}
+	allData := make(map[string]interface{})
+
+	for _, coll := range collections {
+		data, err := repository.CountIDOccurrences(client, coll, 0)
+		if err != nil {
+			log.Printf("Error fetching data for %s: %v", coll, err)
+			continue
+		}
+		allData[coll] = data
+	}
+
+	jsonData, err := json.MarshalIndent(allData, "", "  ")
+	if err != nil {
+		log.Fatalf("Error marshaling JSON: %v", err)
+	}
+
+	err = os.WriteFile("leaderboard.json", jsonData, 0644)
+	if err != nil {
+		log.Fatalf("Error writing file: %v", err)
+	}
+
+	fmt.Println("Successfully exported leaderboard.json")
+}


### PR DESCRIPTION
This PR introduces a daily automated pipeline to extract user leaderboard statistics and make them available to the frontend `docs` branch.

**Key Changes:**
1. **`cmd/export_leaderboard/main.go`**: A standalone CLI utility that queries the database via `repository.CountIDOccurrences` for the `CrocEnLeader`, `WordleEn`, `ScramyEn`, and `GeographyPoints` collections. It outputs a consolidated map to `leaderboard.json`.
2. **`.github/workflows/leaderboard-sync.yml`**: A cron-based GitHub Action (running daily at midnight UTC, with `workflow_dispatch` enabled for testing) that checks out the repo, executes the Go export script, and cleanly switches git context to the `docs` branch (creating it as an orphan if it doesn't exist). It then adds the JSON file and pushes it directly, preventing any main application source code from merging into the frontend repository branch.

---
*PR created automatically by Jules for task [9375834575102507324](https://jules.google.com/task/9375834575102507324) started by @MUSTAFA-A-KHAN*