### PR TITLE
feat: add leaderboards view to cosmic data explorer

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -16,7 +16,8 @@ const DATA_SOURCES = {
     'allowed_words_txt': { path: 'controller/translator/allowed_words.txt', type: 'text' },
     'scramy_words_txt': { path: 'controller/translator/scramy_words.txt', type: 'text' },
     'scramy_allowed_words_txt': { path: 'controller/translator/scramy_allowed_words.txt', type: 'text' },
-    'translator_banned_users': { path: 'translator_banned_users.json', type: 'json' }
+    'translator_banned_users': { path: 'translator_banned_users.json', type: 'json' },
+    'leaderboards': { customUrl: `https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/docs/leaderboard.json`, type: 'json' }
 };
 
 let currentData = null;
@@ -362,7 +363,8 @@ async function loadData(source) {
         currentData = null;
         currentType = source.type;
 
-        const response = await fetch(RAW_BASE_URL + source.path);
+        const fetchUrl = source.customUrl ? source.customUrl : RAW_BASE_URL + source.path;
+        const response = await fetch(fetchUrl);
         if (!response.ok) throw new Error(`Fetch Failed: ${response.status}`);
 
         if (source.type === 'json') {

--- a/docs/index.html
+++ b/docs/index.html
@@ -80,6 +80,14 @@
                 <button class="explore-btn" data-target="translator_banned_users">ACCESS EXILED ENTITIES</button>
             </div>
         </section>
+
+        <section class="scene-section" id="leaderboards">
+            <div class="editorial-text left-align">
+                <h2 class="oversized-type">SECTOR V:<br>CHAMPIONS</h2>
+                <p class="mission-log">ORBITING: LEADERBOARD.JSON</p>
+                <button class="explore-btn" data-target="leaderboards">ACCESS LEADERBOARDS</button>
+            </div>
+        </section>
     </div>
 
     <!-- Data Terminal Modal -->


### PR DESCRIPTION
This PR adds support for viewing the `leaderboard.json` data directly within the Cosmic Data Explorer UI. It updates `docs/index.html` with a new section and a button, and it updates `docs/app.js` to fetch this file using a newly added `customUrl` property since the file lives on the `docs` branch.

---
*PR created automatically by Jules for task [16888571028924110374](https://jules.google.com/task/16888571028924110374) started by @MUSTAFA-A-KHAN*