### PR TITLE
Fix anime mode text guess routing

### DIFF
--- a/controller/animebot/animebot.go
+++ b/controller/animebot/animebot.go
@@ -77,12 +77,10 @@ func IsAnimeActive(chatID int64) bool {
 	return exists && state.Active
 }
 
-func HandleGuess(bot *tgbotapi.BotAPI, update tgbotapi.Update, client *mongo.Client) {
-	if update.Message == nil {
+func HandleGuess(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mongo.Client, chatID int64, text string) {
+	if message == nil {
 		return
 	}
-	chatID := update.Message.Chat.ID
-	text := update.Message.Text
 
 	activeGamesMu.Lock()
 	state, exists := activeGames[chatID]
@@ -109,7 +107,7 @@ func HandleGuess(bot *tgbotapi.BotAPI, update tgbotapi.Update, client *mongo.Cli
 		activeGamesMu.Unlock()
 
 		points := 10
-		go repository.InsertWordleBonusDoc(update.Message.From.ID, update.Message.From.FirstName, chatID, client, "AnimePoints", points)
+		go repository.InsertWordleBonusDoc(message.From.ID, message.From.FirstName, chatID, client, "AnimePoints", points)
 
 		view.SendMessage(bot, chatID, "🎉 Correct! It was <b>"+bestAnswer+"</b>!\nYou earned "+strconv.Itoa(points)+" points!")
 	} else {

--- a/controller/bot.go
+++ b/controller/bot.go
@@ -654,6 +654,10 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 			geographybot.HandleGuess(bot, message, client, chatID, message.Text)
 		}
 
+		if animebot.IsAnimeActive(chatID) {
+			animebot.HandleGuess(bot, message, client, chatID, message.Text)
+		}
+
 		// Check user's guess in DM
 		chatState.RLock()
 		word := chatState.Word
@@ -1015,6 +1019,10 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 
 		if geographybot.IsGeographyActive(chatID) {
 			geographybot.HandleGuess(bot, message, client, chatID, message.Text)
+		}
+
+		if animebot.IsAnimeActive(chatID) {
+			animebot.HandleGuess(bot, message, client, chatID, message.Text)
 		}
 
 		chatState.RLock()

--- a/controller/categoryBot/categoryBot.go
+++ b/controller/categoryBot/categoryBot.go
@@ -14,6 +14,7 @@ import (
 	collectibleController "github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/collectible"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/geographybot"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/translator"
+	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/animebot"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/scramybot"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/wordlebot"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/model"
@@ -755,6 +756,10 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 			geographybot.HandleGuess(bot, message, client, chatID, message.Text)
 		}
 
+		if animebot.IsAnimeActive(chatID) {
+			animebot.HandleGuess(bot, message, client, chatID, message.Text)
+		}
+
 		// Check user's guess in DM
 		chatState.RLock()
 		word := chatState.Word
@@ -1188,6 +1193,10 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 
 		if geographybot.IsGeographyActive(chatID) {
 			geographybot.HandleGuess(bot, message, client, chatID, message.Text)
+		}
+
+		if animebot.IsAnimeActive(chatID) {
+			animebot.HandleGuess(bot, message, client, chatID, message.Text)
 		}
 
 		chatState.RLock()


### PR DESCRIPTION
The "Anime mode" text guesses were not being processed because the bot was not routing incoming chat messages to `animebot.HandleGuess`.

This commit adds `animebot.IsAnimeActive(chatID)` checks to both `controller/bot.go` and `controller/categoryBot/categoryBot.go` message loops (in both DM and group contexts) and invokes `animebot.HandleGuess` when appropriate. The signature for `HandleGuess` was also standardized to match other game bots (like Wordle and Scramy).

---
*PR created automatically by Jules for task [11730593701143885431](https://jules.google.com/task/11730593701143885431) started by @MUSTAFA-A-KHAN*