### PR TITLE
🎨 Palette: Add ForceReply for custom word input validation errors

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -3,7 +3,11 @@
 **Learning:** When users launch sub-menus from a main settings menu, failing to provide a back button leads to a frustrating experience where they must dismiss the prompt and re-open the settings menu from scratch.
 
 **Action:** Ensure all multi-level inline keyboard menus have a "🔙 Back" button to smoothly return to the previous level without abandoning the menu structure entirely.
-## 2026-06-10 - Add ForceReply to User Prompts\n**Learning:** To prompt users for specific textual input (e.g., asking for a price or value), using a standard message can be confusing. Using `tgbotapi.ForceReply{ForceReply: true}` automatically opens their keyboard and sets their message as a reply, improving the UX and clarifying intent.\n**Action:** When intercepting user input in a conversation flow, attach `ForceReply` to the prompt message to explicitly guide the user to reply.
-## $(date +%Y-%m-%d) - Add ForceReply to user input messages
-**Learning:** For interactive text-guessing interactions that requires user context, a simple message might be missed or require manual 'replying'. Adding ForceReply to the message ensures the user prompt keyboard forces the user to reply to the bot message, linking the contexts seamlessly.
-**Action:** When creating text prompts in Telegram Bots that wait for user inputs to update a specific state (like a custom word), attach `ForceReply` to the sent message using `tgbotapi.ForceReply{ForceReply: true}`.
+
+## 2024-11-10 - Add ForceReply to User Prompts
+**Learning:** To prompt users for specific textual input (e.g., asking for a price or value), using a standard message can be confusing. Using `tgbotapi.ForceReply{ForceReply: true}` automatically opens their keyboard and sets their message as a reply, improving the UX and clarifying intent.
+**Action:** When intercepting user input in a conversation flow, attach `ForceReply` to the prompt message to explicitly guide the user to reply.
+
+## 2025-01-20 - Use ForceReply for Invalid Custom Words
+**Learning:** For interactive text-guessing interactions that require user context (like inputting a custom word), if the user inputs an invalid string, it is vital to keep the input channel clear and explicit. A simple message response ("Invalid word") might be missed or require manual re-replying. Adding `ForceReply` to the error message ensures the keyboard remains open and explicitly forces the user to try again, reducing friction in conversational forms.
+**Action:** When rejecting invalid user input in a stateful text prompt and asking them to try again, attach `ForceReply` to the error message using `tgbotapi.ForceReply{ForceReply: true}`.

--- a/controller/bot.go
+++ b/controller/bot.go
@@ -10,11 +10,11 @@ import (
 	"sync"
 	"time"
 
+	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/animebot"
 	collectibleController "github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/collectible"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/geographybot"
-	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/translator"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/scramybot"
-	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/animebot"
+	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/translator"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/wordlebot"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/model"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/model/validator"
@@ -634,7 +634,9 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 					}
 					groupState.Unlock()
 				} else {
-					view.SendMessage(bot, chatID, "Invalid word. Please send a valid English word. Or type /cancel to abort.")
+					msg := tgbotapi.NewMessage(chatID, "Invalid word. Please send a valid English word. Or type /cancel to abort.")
+					msg.ReplyMarkup = tgbotapi.ForceReply{ForceReply: true}
+					bot.Send(msg)
 				}
 				return
 			}
@@ -882,9 +884,9 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 	case "geography":
 		geographybot.HandleGeographyCommand(bot, chatID, message.From.FirstName, client)
 		return
-		case "anime":
-			animebot.HandleAnimeCommand(bot, chatID, client)
-			return
+	case "anime":
+		animebot.HandleAnimeCommand(bot, chatID, client)
+		return
 	case "geohint":
 		geographybot.HandleGeographyHint(bot, message, client, chatID, translator.NewTextTranslator())
 		return
@@ -1110,15 +1112,15 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 			log.Printf("Failed to send styled buttons message: %v", err)
 			view.SendMessagehtml(bot, chatID, "Failed to load leaderboard.")
 		}
-			bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
-			return
-		case "statsglobal_anime":
-			markup := service.LeaderBoardListButtons(client, "AnimePoints", 0, callback.Data)
-			err := view.EditMessageTextWithStyledButtons(bot.Token, chatID, callback.Message.MessageID, "🏆 <b>Top 10 Players Leaderboard</b> 🏆\n\n✨ <b>Keep it up and aim for the top!</b> ✨", markup)
-			if err != nil {
-				log.Printf("Failed to send styled buttons message: %v", err)
-				view.SendMessagehtml(bot, chatID, "Failed to load leaderboard.")
-			}
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
+		return
+	case "statsglobal_anime":
+		markup := service.LeaderBoardListButtons(client, "AnimePoints", 0, callback.Data)
+		err := view.EditMessageTextWithStyledButtons(bot.Token, chatID, callback.Message.MessageID, "🏆 <b>Top 10 Players Leaderboard</b> 🏆\n\n✨ <b>Keep it up and aim for the top!</b> ✨", markup)
+		if err != nil {
+			log.Printf("Failed to send styled buttons message: %v", err)
+			view.SendMessagehtml(bot, chatID, "Failed to load leaderboard.")
+		}
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
 		return
 	case "statsgroup_wordguess":
@@ -1293,23 +1295,23 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 			view.SendMessage(bot, chatID, "Failed to generate image.")
 		}
 		return
-		case "statsimg_global_anime":
-			markup := tgbotapi.NewInlineKeyboardMarkup(tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Word Guess Image Global", "statsimg_global_wordguess"), tgbotapi.NewInlineKeyboardButtonData("Wordle Image Global", "statsimg_global_wordle")), tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Scramy Image Global", "statsimg_global_scramy"), tgbotapi.NewInlineKeyboardButtonData("Geography Image Global 🌍", "statsimg_global_geography")), tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Anime Image Global 🎌", "statsimg_global_anime")))
-			bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Generating image..."))
-			imgBytes, err := service.GenerateLeaderboardImage(client, "AnimePoints", 0, "Anime Global Leaderboard")
-			if err == nil {
-				err = view.EditMessageMediaWithStyledButtons(bot.Token, chatID, callback.Message.MessageID, imgBytes, "leaderboard.png", &markup)
-				if err != nil {
-					// Fallback if message wasn't a photo previously
-					photo := tgbotapi.NewPhotoUpload(chatID, tgbotapi.FileBytes{Name: "leaderboard.png", Bytes: imgBytes})
-					photo.ReplyMarkup = markup
-					bot.Send(photo)
-					bot.Send(tgbotapi.NewDeleteMessage(chatID, callback.Message.MessageID))
-				}
-			} else {
-				view.SendMessage(bot, chatID, "Failed to generate image.")
+	case "statsimg_global_anime":
+		markup := tgbotapi.NewInlineKeyboardMarkup(tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Word Guess Image Global", "statsimg_global_wordguess"), tgbotapi.NewInlineKeyboardButtonData("Wordle Image Global", "statsimg_global_wordle")), tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Scramy Image Global", "statsimg_global_scramy"), tgbotapi.NewInlineKeyboardButtonData("Geography Image Global 🌍", "statsimg_global_geography")), tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Anime Image Global 🎌", "statsimg_global_anime")))
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Generating image..."))
+		imgBytes, err := service.GenerateLeaderboardImage(client, "AnimePoints", 0, "Anime Global Leaderboard")
+		if err == nil {
+			err = view.EditMessageMediaWithStyledButtons(bot.Token, chatID, callback.Message.MessageID, imgBytes, "leaderboard.png", &markup)
+			if err != nil {
+				// Fallback if message wasn't a photo previously
+				photo := tgbotapi.NewPhotoUpload(chatID, tgbotapi.FileBytes{Name: "leaderboard.png", Bytes: imgBytes})
+				photo.ReplyMarkup = markup
+				bot.Send(photo)
+				bot.Send(tgbotapi.NewDeleteMessage(chatID, callback.Message.MessageID))
 			}
-			return
+		} else {
+			view.SendMessage(bot, chatID, "Failed to generate image.")
+		}
+		return
 	case "mystats_main":
 		buttons := tgbotapi.NewInlineKeyboardMarkup(
 			tgbotapi.NewInlineKeyboardRow(
@@ -1318,7 +1320,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 			),
 			tgbotapi.NewInlineKeyboardRow(
 				tgbotapi.NewInlineKeyboardButtonData("Scramy", "stats_scramy"),
-					tgbotapi.NewInlineKeyboardButtonData("Anime", "statsglobal_anime"),
+				tgbotapi.NewInlineKeyboardButtonData("Anime", "statsglobal_anime"),
 			),
 		)
 		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "🐊🇮🇳\n📊 Choose game stats to view:")

--- a/controller/categoryBot/categoryBot.go
+++ b/controller/categoryBot/categoryBot.go
@@ -11,11 +11,11 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/animebot"
 	collectibleController "github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/collectible"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/geographybot"
-	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/translator"
-	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/animebot"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/scramybot"
+	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/translator"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/wordlebot"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/model"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/model/validator"
@@ -740,7 +740,9 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 					}
 					groupState.Unlock()
 				} else {
-					view.SendMessage(bot, chatID, "Invalid word. Please send a valid English word. Or type /cancel to abort.")
+					msg := tgbotapi.NewMessage(chatID, "Invalid word. Please send a valid English word. Or type /cancel to abort.")
+					msg.ReplyMarkup = tgbotapi.ForceReply{ForceReply: true}
+					bot.Send(msg)
 				}
 				return
 			}
@@ -953,10 +955,10 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 			view.SendMessageWithButtons(bot, message.Chat.ID, "Click the button below to visit the Emoji Shop!", markup)
 		}
 	case "statsglobal":
-			buttons := tgbotapi.NewInlineKeyboardMarkup(tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Word Guess Global", "statsglobal_wordguess"), tgbotapi.NewInlineKeyboardButtonData("Wordle Global", "statsglobal_wordle")), tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Scramy Global", "statsglobal_scramy"), tgbotapi.NewInlineKeyboardButtonData("Geography Global 🌍", "statsglobal_geography")), tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Anime Global 🎌", "statsglobal_anime")))
+		buttons := tgbotapi.NewInlineKeyboardMarkup(tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Word Guess Global", "statsglobal_wordguess"), tgbotapi.NewInlineKeyboardButtonData("Wordle Global", "statsglobal_wordle")), tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Scramy Global", "statsglobal_scramy"), tgbotapi.NewInlineKeyboardButtonData("Geography Global 🌍", "statsglobal_geography")), tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Anime Global 🎌", "statsglobal_anime")))
 		view.SendMessageWithButtons(bot, chatID, "🐊🇮🇳\n📊 Choose global stats to view:", buttons)
 	case "statsimageglobal":
-			markup := tgbotapi.NewInlineKeyboardMarkup(tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Word Guess Image Global", "statsimg_global_wordguess"), tgbotapi.NewInlineKeyboardButtonData("Wordle Image Global", "statsimg_global_wordle")), tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Scramy Image Global", "statsimg_global_scramy"), tgbotapi.NewInlineKeyboardButtonData("Geography Image Global 🌍", "statsimg_global_geography")), tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Anime Image Global 🎌", "statsimg_global_anime")))
+		markup := tgbotapi.NewInlineKeyboardMarkup(tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Word Guess Image Global", "statsimg_global_wordguess"), tgbotapi.NewInlineKeyboardButtonData("Wordle Image Global", "statsimg_global_wordle")), tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Scramy Image Global", "statsimg_global_scramy"), tgbotapi.NewInlineKeyboardButtonData("Geography Image Global 🌍", "statsimg_global_geography")), tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Anime Image Global 🎌", "statsimg_global_anime")))
 		imgBytes, err := service.GenerateLeaderboardImage(client, "CrocEn", 0, "Word Guess Global Leaderboard")
 		if err == nil {
 			photo := tgbotapi.NewPhotoUpload(chatID, tgbotapi.FileBytes{Name: "leaderboard.png", Bytes: imgBytes})
@@ -1320,15 +1322,15 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 			log.Printf("Failed to send styled buttons message: %v", err)
 			view.SendMessagehtml(bot, chatID, "Failed to load leaderboard.")
 		}
-			bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
-			return
-		case "statsglobal_anime":
-			markup := service.LeaderBoardListButtons(client, "AnimePoints", 0, callback.Data)
-			err := view.EditMessageTextWithStyledButtons(bot.Token, chatID, callback.Message.MessageID, "🏆 <b>Top 10 Players Leaderboard</b> 🏆\n\n✨ <b>Keep it up and aim for the top!</b> ✨", markup)
-			if err != nil {
-				log.Printf("Failed to send styled buttons message: %v", err)
-				view.SendMessagehtml(bot, chatID, "Failed to load leaderboard.")
-			}
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
+		return
+	case "statsglobal_anime":
+		markup := service.LeaderBoardListButtons(client, "AnimePoints", 0, callback.Data)
+		err := view.EditMessageTextWithStyledButtons(bot.Token, chatID, callback.Message.MessageID, "🏆 <b>Top 10 Players Leaderboard</b> 🏆\n\n✨ <b>Keep it up and aim for the top!</b> ✨", markup)
+		if err != nil {
+			log.Printf("Failed to send styled buttons message: %v", err)
+			view.SendMessagehtml(bot, chatID, "Failed to load leaderboard.")
+		}
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
 		return
 	case "statsgroup_wordguess":
@@ -1410,7 +1412,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		bot.Send(tgbotapi.NewDeleteMessage(chatID, callback.Message.MessageID))
 		return
 	case "statsimg_global_geography":
-			markup := tgbotapi.NewInlineKeyboardMarkup(tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Word Guess Image Global", "statsimg_global_wordguess"), tgbotapi.NewInlineKeyboardButtonData("Wordle Image Global", "statsimg_global_wordle")), tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Scramy Image Global", "statsimg_global_scramy"), tgbotapi.NewInlineKeyboardButtonData("Geography Image Global 🌍", "statsimg_global_geography")), tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Anime Image Global 🎌", "statsimg_global_anime")))
+		markup := tgbotapi.NewInlineKeyboardMarkup(tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Word Guess Image Global", "statsimg_global_wordguess"), tgbotapi.NewInlineKeyboardButtonData("Wordle Image Global", "statsimg_global_wordle")), tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Scramy Image Global", "statsimg_global_scramy"), tgbotapi.NewInlineKeyboardButtonData("Geography Image Global 🌍", "statsimg_global_geography")), tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Anime Image Global 🎌", "statsimg_global_anime")))
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Generating image..."))
 		bot.Send(tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "Generating image... Please wait ⏳"))
 		imgBytes, err := service.GenerateLeaderboardImage(client, "GeographyPoints", 0, "Geography Global Leaderboard")
@@ -1421,20 +1423,20 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		} else {
 			view.SendMessage(bot, chatID, "Failed to generate image.")
 		}
-			bot.Send(tgbotapi.NewDeleteMessage(chatID, callback.Message.MessageID))
-			return
-		case "statsimg_global_anime":
-			markup := tgbotapi.NewInlineKeyboardMarkup(tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Word Guess Image Global", "statsimg_global_wordguess"), tgbotapi.NewInlineKeyboardButtonData("Wordle Image Global", "statsimg_global_wordle")), tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Scramy Image Global", "statsimg_global_scramy"), tgbotapi.NewInlineKeyboardButtonData("Geography Image Global 🌍", "statsimg_global_geography")), tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Anime Image Global 🎌", "statsimg_global_anime")))
-			bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Generating image..."))
-			bot.Send(tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "Generating image... Please wait ⏳"))
-			imgBytes, err := service.GenerateLeaderboardImage(client, "AnimePoints", 0, "Anime Global Leaderboard")
-			if err == nil {
-				photo := tgbotapi.NewPhotoUpload(chatID, tgbotapi.FileBytes{Name: "leaderboard.png", Bytes: imgBytes})
-				photo.ReplyMarkup = markup
-				bot.Send(photo)
-			} else {
-				view.SendMessage(bot, chatID, "Failed to generate image.")
-			}
+		bot.Send(tgbotapi.NewDeleteMessage(chatID, callback.Message.MessageID))
+		return
+	case "statsimg_global_anime":
+		markup := tgbotapi.NewInlineKeyboardMarkup(tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Word Guess Image Global", "statsimg_global_wordguess"), tgbotapi.NewInlineKeyboardButtonData("Wordle Image Global", "statsimg_global_wordle")), tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Scramy Image Global", "statsimg_global_scramy"), tgbotapi.NewInlineKeyboardButtonData("Geography Image Global 🌍", "statsimg_global_geography")), tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Anime Image Global 🎌", "statsimg_global_anime")))
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Generating image..."))
+		bot.Send(tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "Generating image... Please wait ⏳"))
+		imgBytes, err := service.GenerateLeaderboardImage(client, "AnimePoints", 0, "Anime Global Leaderboard")
+		if err == nil {
+			photo := tgbotapi.NewPhotoUpload(chatID, tgbotapi.FileBytes{Name: "leaderboard.png", Bytes: imgBytes})
+			photo.ReplyMarkup = markup
+			bot.Send(photo)
+		} else {
+			view.SendMessage(bot, chatID, "Failed to generate image.")
+		}
 		bot.Send(tgbotapi.NewDeleteMessage(chatID, callback.Message.MessageID))
 		return
 	case "statsimg_group_wordguess":
@@ -1501,7 +1503,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 			),
 			tgbotapi.NewInlineKeyboardRow(
 				tgbotapi.NewInlineKeyboardButtonData("Scramy", "stats_scramy"),
-					tgbotapi.NewInlineKeyboardButtonData("Anime", "statsglobal_anime"),
+				tgbotapi.NewInlineKeyboardButtonData("Anime", "statsglobal_anime"),
 			),
 		)
 		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "🐊🇮🇳\n📊 Choose game stats to view:")


### PR DESCRIPTION
💡 What: Added `ForceReply` markup to the "Invalid word" prompt in the custom word input flow.
🎯 Why: When a user enters an invalid custom word, they need to try again. Previously, they received a regular message, which required them to manually click "Reply" again or potentially lose context. By using `ForceReply`, the keyboard automatically opens and prompts them explicitly to reply to the error message, streamlining the interaction.
♿ Accessibility: Reduces friction and cognitive load when interacting with sequential conversational prompts.

---
*PR created automatically by Jules for task [1108277961721732234](https://jules.google.com/task/1108277961721732234) started by @MUSTAFA-A-KHAN*