### PR TITLE
🎨 Palette: Add /cancelanime command for active game UX

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-20 - Adding explicit escape hatches for interactive modes
+**Learning:** When adding new interactive text-based modes (like guessing games) to a Telegram bot, users can easily get stuck in an active state if they change their mind or don't know the answer. Missing a cancellation command (like `/cancelanime`) degrades UX and traps the user in a mode they didn't intend to stay in.
+**Action:** Always provide and consistently name explicit cancellation commands (e.g., `/cancel<mode>`) that clear the active state memory and return the user to the default bot flow.

--- a/controller/animebot/animebot.go
+++ b/controller/animebot/animebot.go
@@ -77,6 +77,17 @@ func IsAnimeActive(chatID int64) bool {
 	return exists && state.Active
 }
 
+func CancelAnime(chatID int64) bool {
+	activeGamesMu.Lock()
+	defer activeGamesMu.Unlock()
+
+	if state, exists := activeGames[chatID]; exists && state.Active {
+		delete(activeGames, chatID)
+		return true
+	}
+	return false
+}
+
 func HandleGuess(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mongo.Client, chatID int64, text string) {
 	if message == nil {
 		return

--- a/controller/bot.go
+++ b/controller/bot.go
@@ -446,6 +446,13 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 		case "anime":
 			animebot.HandleAnimeCommand(bot, chatID, client)
 			return
+		case "cancelanime":
+			if animebot.CancelAnime(chatID) {
+				view.SendMessage(bot, chatID, "Anime game cancelled.")
+			} else {
+				view.SendMessage(bot, chatID, "No active Anime game.")
+			}
+			return
 		case "addwordlepoints":
 			if message.From.ID != int(adminID) {
 				return
@@ -893,6 +900,12 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 			view.SendMessage(bot, chatID, "Geography game cancelled.")
 		} else {
 			view.SendMessage(bot, chatID, "No active Geography game.")
+		}
+	case "cancelanime":
+		if animebot.CancelAnime(chatID) {
+			view.SendMessage(bot, chatID, "Anime game cancelled.")
+		} else {
+			view.SendMessage(bot, chatID, "No active Anime game.")
 		}
 	case "word":
 		chatState.RLock()

--- a/controller/categoryBot/categoryBot.go
+++ b/controller/categoryBot/categoryBot.go
@@ -427,6 +427,12 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 			} else {
 				view.SendMessage(bot, chatID, "No active Geography game.")
 			}
+		case "cancelanime":
+			if animebot.CancelAnime(chatID) {
+				view.SendMessage(bot, chatID, "Anime game cancelled.")
+			} else {
+				view.SendMessage(bot, chatID, "No active Anime game.")
+			}
 		case "exportdata":
 			if message.From.ID != int(adminID) {
 				log.Printf("not an admin")
@@ -909,6 +915,12 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 			view.SendMessage(bot, chatID, "Geography game cancelled.")
 		} else {
 			view.SendMessage(bot, chatID, "No active Geography game.")
+		}
+	case "cancelanime":
+		if animebot.CancelAnime(chatID) {
+			view.SendMessage(bot, chatID, "Anime game cancelled.")
+		} else {
+			view.SendMessage(bot, chatID, "No active Anime game.")
 		}
 	case "stats":
 		buttons := tgbotapi.NewInlineKeyboardMarkup(tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Word Guess Group", "statsgroup_wordguess"), tgbotapi.NewInlineKeyboardButtonData("Wordle Group", "statsgroup_wordle")), tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Scramy Group", "statsgroup_scramy"), tgbotapi.NewInlineKeyboardButtonData("Geography Group 🌍", "statsgroup_geography")))


### PR DESCRIPTION
This PR adds a `/cancelanime` command to allow users to exit an active Anime guessing game.

### What
Added a new `CancelAnime(chatID)` function in `controller/animebot/animebot.go` which safely deletes the active game state for a chat. Bound this function to the `/cancelanime` command in both `bot.go` and `categoryBot.go`.

### Why
When users trigger a game mode by mistake or don't know the answer, they need an explicit "escape hatch" to cancel the active state so their subsequent messages aren't intercepted. This matches the existing UX patterns of `/cancelgeo` and brings consistency to the bot's interactive modules.

### Accessibility
This improves conversational accessibility by preventing users from feeling "stuck" in a specific bot flow.

---
*PR created automatically by Jules for task [107954253778252378](https://jules.google.com/task/107954253778252378) started by @MUSTAFA-A-KHAN*