### PR TITLE
feat(anime): add /animehint command for dynamic anime sticker hints

### DIFF
--- a/controller/animebot/hint.go
+++ b/controller/animebot/hint.go
@@ -1,0 +1,67 @@
+package animebot
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/view"
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+)
+
+type jikanResponse struct {
+	Data []struct {
+		Images struct {
+			Webp struct {
+				ImageURL string `json:"image_url"`
+			} `json:"webp"`
+		} `json:"images"`
+	} `json:"data"`
+}
+
+// HandleAnimeHint fetches the cover image from Jikan API and sends it as a sticker hint
+func HandleAnimeHint(bot *tgbotapi.BotAPI, chatID int64) {
+	activeGamesMu.Lock()
+	state, exists := activeGames[chatID]
+	activeGamesMu.Unlock()
+
+	if !exists || !state.Active {
+		view.SendMessage(bot, chatID, "No active Anime game. Start one with /anime!")
+		return
+	}
+
+	answer := state.Question.Answers[0]
+
+	// Basic normalization to improve search
+	searchQuery := answer
+	if strings.Contains(strings.ToLower(answer), "fullmetal alchemist") {
+		searchQuery = "Fullmetal Alchemist"
+	}
+
+	apiURL := fmt.Sprintf("https://api.jikan.moe/v4/anime?q=%s", url.QueryEscape(searchQuery))
+	resp, err := http.Get(apiURL)
+	if err != nil {
+		view.SendMessage(bot, chatID, "Failed to get hint right now 😔")
+		return
+	}
+	defer resp.Body.Close()
+
+	var jResp jikanResponse
+	if err := json.NewDecoder(resp.Body).Decode(&jResp); err != nil {
+		view.SendMessage(bot, chatID, "Failed to get hint right now 😔")
+		return
+	}
+
+	if len(jResp.Data) > 0 {
+		imageURL := jResp.Data[0].Images.Webp.ImageURL
+		err := view.SendSticker(bot, chatID, imageURL)
+		if err != nil {
+			// fallback if sticker send fails
+			view.SendMessagehtml(bot, chatID, fmt.Sprintf("Here is a hint: <a href=\"%s\">Image</a>", imageURL))
+		}
+	} else {
+		view.SendMessage(bot, chatID, "Couldn't find a picture hint for this one! 🤔")
+	}
+}

--- a/controller/bot.go
+++ b/controller/bot.go
@@ -903,6 +903,9 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 		} else {
 			view.SendMessage(bot, chatID, "No active Geography game.")
 		}
+	case "animehint":
+		animebot.HandleAnimeHint(bot, chatID)
+		return
 	case "cancelanime":
 		if animebot.CancelAnime(chatID) {
 			view.SendMessage(bot, chatID, "Anime game cancelled.")

--- a/controller/categoryBot/categoryBot.go
+++ b/controller/categoryBot/categoryBot.go
@@ -417,6 +417,9 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 		case "anime":
 			animebot.HandleAnimeCommand(bot, chatID, client)
 			return
+		case "animehint":
+			animebot.HandleAnimeHint(bot, chatID)
+			return
 		case "geohint":
 			geographybot.HandleGeographyHint(bot, message, client, chatID, translator.NewTextTranslator())
 			return
@@ -909,6 +912,9 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 		return
 	case "anime":
 		animebot.HandleAnimeCommand(bot, chatID, client)
+		return
+	case "animehint":
+		animebot.HandleAnimeHint(bot, chatID)
 		return
 	case "geohint":
 		geographybot.HandleGeographyHint(bot, message, client, chatID, translator.NewTextTranslator())


### PR DESCRIPTION
Implements a new hint system for the anime emote guessing game. Users can now type `/animehint` to receive a dynamic sticker containing the cover image of the anime they are currently trying to guess.

It utilizes the Jikan API (MyAnimeList) to dynamically fetch the cover `.webp` image based on the active guess answer, resolving the problem of having to manage a hardcoded list of Telegram sticker file IDs inside the `anime.json` configuration file.

---
*PR created automatically by Jules for task [1192675367493201582](https://jules.google.com/task/1192675367493201582) started by @MUSTAFA-A-KHAN*