### PR TITLE
fix: prevent multiple active anime games and enforce SFW hints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-.gocache
+telegram-bot-anime

--- a/controller/animebot/animebot.go
+++ b/controller/animebot/animebot.go
@@ -60,7 +60,15 @@ func HandleAnimeCommand(bot *tgbotapi.BotAPI, chatID int64, client *mongo.Client
 	activeGamesMu.Lock()
 	defer activeGamesMu.Unlock()
 
+	state, exists := activeGames[chatID]
+	if exists && state.Active {
+		msg, _ := view.SendMessage(bot, chatID, "An Anime game is already active! Answer the current question or wait for it to finish.")
+		view.DeleteMessageAfterDelay(bot, chatID, msg.MessageID, 2*time.Second)
+		return
+	}
+
 	question := animeList[rng.Intn(len(animeList))]
+
 	activeGames[chatID] = &GameState{
 		Active:   true,
 		Question: question,

--- a/controller/animebot/hint.go
+++ b/controller/animebot/hint.go
@@ -40,7 +40,7 @@ func HandleAnimeHint(bot *tgbotapi.BotAPI, chatID int64) {
 		searchQuery = "Fullmetal Alchemist"
 	}
 
-	apiURL := fmt.Sprintf("https://api.jikan.moe/v4/anime?q=%s", url.QueryEscape(searchQuery))
+	apiURL := fmt.Sprintf("https://api.jikan.moe/v4/anime?q=%s&sfw=true", url.QueryEscape(searchQuery))
 	resp, err := http.Get(apiURL)
 	if err != nil {
 		view.SendMessage(bot, chatID, "Failed to get hint right now 😔")


### PR DESCRIPTION
This PR fixes an issue where multiple `/anime` commands sent concurrently could overwrite the active game state, causing conflicts. It also resolves a concern regarding NSFW image hints (such as those from "Ghost in the Shell") by adding the `sfw=true` parameter to the Jikan API request.

---
*PR created automatically by Jules for task [8102117514826594803](https://jules.google.com/task/8102117514826594803) started by @MUSTAFA-A-KHAN*