### PR TITLE
UX: Add ForceReply for invalid/duplicate Wordle guesses

### DIFF
--- a/controller/wordlebot/wordlebot.go
+++ b/controller/wordlebot/wordlebot.go
@@ -512,7 +512,9 @@ func HandleGuess(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mongo.
 	wordsMutex.RUnlock()
 
 	if !isValid {
-		view.SendMessage(bot, chatID, fmt.Sprintf("❌ %s is not a valid word.", strings.ToUpper(guess)))
+		msg := tgbotapi.NewMessage(chatID, fmt.Sprintf("❌ %s is not a valid word. Try again!", strings.ToUpper(guess)))
+		msg.ReplyMarkup = tgbotapi.ForceReply{ForceReply: true}
+		bot.Send(msg)
 		return
 	}
 
@@ -525,7 +527,9 @@ func HandleGuess(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mongo.
 	}
 
 	if alreadyGuessed {
-		view.SendMessage(bot, chatID, "⚠️ This word was already guessed!")
+		msg := tgbotapi.NewMessage(chatID, "⚠️ This word was already guessed! Try again!")
+		msg.ReplyMarkup = tgbotapi.ForceReply{ForceReply: true}
+		bot.Send(msg)
 		return
 	}
 


### PR DESCRIPTION
UX Improvement in Wordle Bot:
Added `ForceReply` to the error messages when a user inputs an invalid word or a word that has already been guessed. This prompts their keyboard to automatically open, clarifying that they need to try again immediately, thus reducing friction in the interactive flow.

---
*PR created automatically by Jules for task [110191631490170494](https://jules.google.com/task/110191631490170494) started by @MUSTAFA-A-KHAN*