### PR TITLE
feat: add play again button to anime bot

### DIFF
--- a/controller/animebot/animebot.go
+++ b/controller/animebot/animebot.go
@@ -117,7 +117,9 @@ func HandleGuess(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mongo.
 		points := 10
 		go repository.InsertWordleBonusDoc(message.From.ID, message.From.FirstName, chatID, client, "AnimePoints", points)
 
-		view.SendMessagehtml(bot, chatID, "🎉 Correct! It was <b>"+bestAnswer+"</b>!\nYou earned "+strconv.Itoa(points)+" points!")
+		successMsg := "🎉 Correct! It was <b>" + bestAnswer + "</b>!\nYou earned " + strconv.Itoa(points) + " points!"
+		markup := tgbotapi.NewInlineKeyboardMarkup(tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Play Again 🎌", "anime_start")))
+		view.SendMessagehtmlWithButtons(bot, chatID, successMsg, markup)
 	} else {
 		// Not correct, maybe close but give a generic message
 		// view.SendMessagehtml(bot, chatID, "❌ Nope, try again!")

--- a/controller/bot.go
+++ b/controller/bot.go
@@ -1750,6 +1750,10 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		geographybot.HandleGeographyCommand(bot, chatID, callback.From.FirstName, client)
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Geography Started!"))
 		return
+	case "anime_start":
+		animebot.HandleAnimeCommand(bot, chatID, client)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Anime Started!"))
+		return
 	case "cancel_new_scramy":
 		if scramybot.CancelPendingGame(bot, chatID, callback.From.FirstName) {
 			bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Cancelled new Scramy game request."))

--- a/controller/categoryBot/categoryBot.go
+++ b/controller/categoryBot/categoryBot.go
@@ -1968,6 +1968,10 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		geographybot.HandleGeographyCommand(bot, chatID, callback.From.FirstName, client)
 		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Geography Started!"))
 		return
+	case "anime_start":
+		animebot.HandleAnimeCommand(bot, chatID, client)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Anime Started!"))
+		return
 	case "cancel_new_scramy":
 		if scramybot.CancelPendingGame(bot, chatID, callback.From.FirstName) {
 			bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Cancelled new Scramy game request."))

--- a/view/response.go
+++ b/view/response.go
@@ -223,3 +223,14 @@ func DeleteMessageAfterDelay(bot *tgbotapi.BotAPI, chatID int64, messageID int, 
 	}
 
 }
+
+// SendMessagehtmlWithButtons sends an HTML message with inline keyboard buttons to the user
+func SendMessagehtmlWithButtons(bot *tgbotapi.BotAPI, chatID int64, text string, buttons tgbotapi.InlineKeyboardMarkup) error {
+	msg := tgbotapi.NewMessage(chatID, text)
+	msg.ParseMode = tgbotapi.ModeHTML
+	if len(buttons.InlineKeyboard) > 0 {
+		msg.ReplyMarkup = buttons
+	}
+	_, err := bot.Send(msg)
+	return err
+}


### PR DESCRIPTION
Added a "Play Again 🎌" button that appears when an anime game is completed, allowing users to restart the game directly. Registered the "anime_start" callback handler in the global bot and category bot listeners to trigger `animebot.HandleAnimeCommand`.

---
*PR created automatically by Jules for task [18197232454235205066](https://jules.google.com/task/18197232454235205066) started by @MUSTAFA-A-KHAN*