### PR TITLE
🎨 Palette: [UX improvement] Unify cancel commands for interactive games

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-25 - Unified Cancel Commands for Interactive Games
+**Learning:** Having standard navigational and state-reset commands (like /cancelgeo, /cancelanime) available across all context modes (DMs and groups, both standard and category bot) prevents users from becoming stuck in unwanted game states and provides a more pleasant, predictable interface.
+**Action:** Always ensure new interactive modes implemented have a corresponding explicit cancel command mapped in both `bot.go` and `categoryBot.go` to maintain consistent conversational UX.

--- a/controller/categoryBot/categoryBot.go
+++ b/controller/categoryBot/categoryBot.go
@@ -430,6 +430,12 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 			} else {
 				view.SendMessage(bot, chatID, "No active Geography game.")
 			}
+		case "cancelanime":
+			if animebot.CancelAnime(chatID) {
+				view.SendMessage(bot, chatID, "Anime game cancelled.")
+			} else {
+				view.SendMessage(bot, chatID, "No active Anime game.")
+			}
 		case "exportdata":
 			if message.From.ID != int(adminID) {
 				log.Printf("not an admin")
@@ -924,6 +930,12 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 			view.SendMessage(bot, chatID, "Geography game cancelled.")
 		} else {
 			view.SendMessage(bot, chatID, "No active Geography game.")
+		}
+	case "cancelanime":
+		if animebot.CancelAnime(chatID) {
+			view.SendMessage(bot, chatID, "Anime game cancelled.")
+		} else {
+			view.SendMessage(bot, chatID, "No active Anime game.")
 		}
 	case "stats":
 		buttons := tgbotapi.NewInlineKeyboardMarkup(tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Word Guess Group", "statsgroup_wordguess"), tgbotapi.NewInlineKeyboardButtonData("Wordle Group", "statsgroup_wordle")), tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("Scramy Group", "statsgroup_scramy"), tgbotapi.NewInlineKeyboardButtonData("Geography Group 🌍", "statsgroup_geography")))


### PR DESCRIPTION
🎨 Palette: Unified cancel commands for interactive games.

This PR implements the missing `/cancelanime` command support in `controller/categoryBot/categoryBot.go`, allowing users to exit the anime game symmetrically with how it's done for `/cancelgeo`. Ensuring standard escape hatches in text-based conversational interfaces prevents users from becoming stuck, leading to a much smoother UX.

A journal entry has been added to `.jules/palette.md` to record this learning.

---
*PR created automatically by Jules for task [10469571101991895592](https://jules.google.com/task/10469571101991895592) started by @MUSTAFA-A-KHAN*