### PR TITLE
🎨 Pixel: Fix Telegram Markdown formatting for Settings headers

### DIFF
--- a/.jules/pixel.md
+++ b/.jules/pixel.md
@@ -3,3 +3,9 @@
 **Learning:** When displaying multiple statistics for a user, using basic text with line breaks (`\n`) creates a dense, unstructured view. Switching to HTML formatting with `<b>` tags for labels, using emojis for visual hierarchy, and creating empty lines as section separators significantly improves scannability and presentation.
 
 **Action:** Whenever sending statistics or multi-field data, format it as a structured card utilizing emojis and bold text via HTML or Markdown instead of plain text dumps.
+
+## 2024-06-20 - Telegram Markdown Bolding
+
+**Learning:** Telegram's simple `Markdown` mode is not identical to standard web Markdown. While standard Markdown uses double asterisks (`**bold**`) for bold text, Telegram's parser only recognizes single asterisks (`*bold*`) for bolding. Using double asterisks results in them being rendered literally as text (e.g., `**Settings**`), adding visual clutter and confusing users.
+
+**Action:** When sending messages using `tgbotapi.ModeMarkdown` (or just `"Markdown"`), strictly use single asterisks (`*`) for bold styling and avoid double asterisks (`**`). Use `ModeMarkdownV2` if more complex formatting features are necessary, but simple `ModeMarkdown` requires the simpler syntax.

--- a/controller/bot.go
+++ b/controller/bot.go
@@ -745,7 +745,7 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 				tgbotapi.NewInlineKeyboardButtonData("Geography Settings 🌍", "setting_geography_main"),
 			),
 		)
-		view.SendMessageWithButtons(bot, message.Chat.ID, "⚙️ **Settings**\nChoose a setting to configure:", buttons)
+		view.SendMessageWithButtons(bot, message.Chat.ID, "⚙️ *Settings*\nChoose a setting to configure:", buttons)
 	case "geosettings":
 		buttons := tgbotapi.NewInlineKeyboardMarkup(
 			tgbotapi.NewInlineKeyboardRow(
@@ -1056,7 +1056,7 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 			chatState.reset(chatID)
 
 			// THE CHARACTER UPGRADE:
-			victoryText := fmt.Sprintf("🎊 *The forest erupts in cheers!*\n\n🦉 \"Correct. The word was indeed **%s**.\"\n🐊 \"WOW! [%s](tg://user?id=%d) is a genius! Can we play again? Can we?!\"",
+			victoryText := fmt.Sprintf("🎊 *The forest erupts in cheers!*\n\n🦉 \"Correct. The word was indeed *%s*.\"\n🐊 \"WOW! [%s](tg://user?id=%d) is a genius! Can we play again? Can we?!\"",
 				word, message.From.FirstName, message.From.ID)
 
 			if StickerCrocHappy != "" {
@@ -1495,7 +1495,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 				tgbotapi.NewInlineKeyboardButtonData("🔙 Back", "settings_main"),
 			),
 		)
-		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ **Scramy Letters Setting**\nChoose the letter style for Scramy:")
+		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ *Scramy Letters Setting*\nChoose the letter style for Scramy:")
 		editMsg.ReplyMarkup = &buttons
 		editMsg.ParseMode = tgbotapi.ModeMarkdown
 		bot.Send(editMsg)
@@ -1517,7 +1517,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		return
 	case "set_scramy_squared":
 		scramybot.UpdateScramyLetterView(chatID, "squared", client)
-		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "✅ Scramy letters updated to **Squared**.")
+		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "✅ Scramy letters updated to *Squared*.")
 		editMsg.ParseMode = tgbotapi.ModeMarkdown
 		buttons := tgbotapi.NewInlineKeyboardMarkup(tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("🔙 Back to Settings", "settings_main")))
 		editMsg.ReplyMarkup = &buttons
@@ -1526,7 +1526,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		return
 	case "set_scramy_normal":
 		scramybot.UpdateScramyLetterView(chatID, "normal", client)
-		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "✅ Scramy letters updated to **Normal**.")
+		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "✅ Scramy letters updated to *Normal*.")
 		editMsg.ParseMode = tgbotapi.ModeMarkdown
 		buttons := tgbotapi.NewInlineKeyboardMarkup(tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("🔙 Back to Settings", "settings_main")))
 		editMsg.ReplyMarkup = &buttons
@@ -1590,7 +1590,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 				tgbotapi.NewInlineKeyboardButtonData("🔙 Back", "settings_main"),
 			),
 		)
-		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ **Wordle Color Setting**\nChoose the color used for missing letters:")
+		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ *Wordle Color Setting*\nChoose the color used for missing letters:")
 		editMsg.ReplyMarkup = &buttons
 		editMsg.ParseMode = tgbotapi.ModeMarkdown
 		bot.Send(editMsg)
@@ -1623,7 +1623,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 				tgbotapi.NewInlineKeyboardButtonData("🔙 Back", "settings_main"),
 			),
 		)
-		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ **Wordle View Setting**\nChoose how you want Wordle results to be displayed:")
+		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ *Wordle View Setting*\nChoose how you want Wordle results to be displayed:")
 		editMsg.ReplyMarkup = &buttons
 		editMsg.ParseMode = tgbotapi.ModeMarkdown
 		bot.Send(editMsg)
@@ -1653,7 +1653,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		return
 	case "set_wordle_view_text":
 		wordlebot.UpdateWordleViewType(chatID, "text", client)
-		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "✅ Wordle view updated to **Text**.")
+		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "✅ Wordle view updated to *Text*.")
 		editMsg.ParseMode = tgbotapi.ModeMarkdown
 		buttons := tgbotapi.NewInlineKeyboardMarkup(tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("🔙 Back to Settings", "settings_main")))
 		editMsg.ReplyMarkup = &buttons
@@ -1662,7 +1662,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		return
 	case "set_wordle_view_image":
 		wordlebot.UpdateWordleViewType(chatID, "image", client)
-		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "✅ Wordle view updated to **Image**.")
+		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "✅ Wordle view updated to *Image*.")
 		editMsg.ParseMode = tgbotapi.ModeMarkdown
 		buttons := tgbotapi.NewInlineKeyboardMarkup(tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("🔙 Back to Settings", "settings_main")))
 		editMsg.ReplyMarkup = &buttons
@@ -1671,7 +1671,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		return
 	case "set_wordle_color_classic":
 		wordlebot.UpdateWordleColor(chatID, "classic", client)
-		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "✅ Wordle color updated to **Classic** (🟥).")
+		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "✅ Wordle color updated to *Classic* (🟥).")
 		editMsg.ParseMode = tgbotapi.ModeMarkdown
 		buttons := tgbotapi.NewInlineKeyboardMarkup(tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("🔙 Back to Settings", "settings_main")))
 		editMsg.ReplyMarkup = &buttons
@@ -1680,7 +1680,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		return
 	case "set_wordle_color_dark":
 		wordlebot.UpdateWordleColor(chatID, "dark", client)
-		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "✅ Wordle color updated to **Dark** (⬛).")
+		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "✅ Wordle color updated to *Dark* (⬛).")
 		editMsg.ParseMode = tgbotapi.ModeMarkdown
 		buttons := tgbotapi.NewInlineKeyboardMarkup(tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("🔙 Back to Settings", "settings_main")))
 		editMsg.ReplyMarkup = &buttons
@@ -1689,7 +1689,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		return
 	case "set_wordle_color_light":
 		wordlebot.UpdateWordleColor(chatID, "light", client)
-		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "✅ Wordle color updated to **Light** (⬜).")
+		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "✅ Wordle color updated to *Light* (⬜).")
 		editMsg.ParseMode = tgbotapi.ModeMarkdown
 		buttons := tgbotapi.NewInlineKeyboardMarkup(tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("🔙 Back to Settings", "settings_main")))
 		editMsg.ReplyMarkup = &buttons

--- a/controller/categoryBot/categoryBot.go
+++ b/controller/categoryBot/categoryBot.go
@@ -888,7 +888,7 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 				tgbotapi.NewInlineKeyboardButtonData("Geography Settings 🌍", "setting_geography_main"),
 			),
 		)
-		view.SendMessageWithButtons(bot, message.Chat.ID, "⚙️ **Settings**\nChoose a setting to configure:", buttons)
+		view.SendMessageWithButtons(bot, message.Chat.ID, "⚙️ *Settings*\nChoose a setting to configure:", buttons)
 		return
 	case "geosettings":
 		buttons := tgbotapi.NewInlineKeyboardMarkup(
@@ -1675,7 +1675,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 				tgbotapi.NewInlineKeyboardButtonData("🔙 Back", "settings_main"),
 			),
 		)
-		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ **Scramy Letters Setting**\nChoose the letter style for Scramy:")
+		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ *Scramy Letters Setting*\nChoose the letter style for Scramy:")
 		editMsg.ReplyMarkup = &buttons
 		editMsg.ParseMode = tgbotapi.ModeMarkdown
 		bot.Send(editMsg)
@@ -1808,7 +1808,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 				tgbotapi.NewInlineKeyboardButtonData("🔙 Back", "settings_main"),
 			),
 		)
-		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ **Wordle Color Setting**\nChoose the color used for missing letters:")
+		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ *Wordle Color Setting*\nChoose the color used for missing letters:")
 		editMsg.ReplyMarkup = &buttons
 		editMsg.ParseMode = tgbotapi.ModeMarkdown
 		bot.Send(editMsg)
@@ -1841,7 +1841,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 				tgbotapi.NewInlineKeyboardButtonData("🔙 Back", "settings_main"),
 			),
 		)
-		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ **Wordle View Setting**\nChoose how you want Wordle results to be displayed:")
+		editMsg := tgbotapi.NewEditMessageText(chatID, callback.Message.MessageID, "⚙️ *Wordle View Setting*\nChoose how you want Wordle results to be displayed:")
 		editMsg.ReplyMarkup = &buttons
 		editMsg.ParseMode = tgbotapi.ModeMarkdown
 		bot.Send(editMsg)


### PR DESCRIPTION
### 💡 What
Replaced double asterisks (`**`) with single asterisks (`*`) in Settings menu headers across `controller/bot.go` and `controller/categoryBot/categoryBot.go`.

### 🎯 Why
Telegram's standard `ModeMarkdown` syntax only recognizes single asterisks (`*bold*`) for bolding text. Using double asterisks (`**bold**`) results in them being rendered literally as text on the user's screen, causing visual clutter and failing to apply the intended styling.

### 📸 Before
```
⚙️ **Settings**
Choose a setting to configure:
```

### ✨ After
```
⚙️ *Settings*
Choose a setting to configure:
```

### 📱 Mobile
Improves scannability and visual hierarchy for mobile users by eliminating unparsed markdown asterisks and properly rendering bold text.

---
*PR created automatically by Jules for task [16994472157953622235](https://jules.google.com/task/16994472157953622235) started by @MUSTAFA-A-KHAN*