### PR TITLE
Remove ForceReply on invalid guesses in Wordlebot

### DIFF
--- a/controller/wordlebot/wordlebot.go
+++ b/controller/wordlebot/wordlebot.go
@@ -519,7 +519,6 @@ func HandleGuess(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mongo.
 
 	if !isValid {
 		msg := tgbotapi.NewMessage(chatID, fmt.Sprintf("❌ %s is not a valid word. Try again!", strings.ToUpper(guess)))
-		msg.ReplyMarkup = tgbotapi.ForceReply{ForceReply: true}
 		bot.Send(msg)
 		return
 	}
@@ -534,7 +533,6 @@ func HandleGuess(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mongo.
 
 	if alreadyGuessed {
 		msg := tgbotapi.NewMessage(chatID, "⚠️ This word was already guessed! Try again!")
-		msg.ReplyMarkup = tgbotapi.ForceReply{ForceReply: true}
 		bot.Send(msg)
 		return
 	}


### PR DESCRIPTION
Removed `tgbotapi.ForceReply{ForceReply: true}` from the "not a valid word" and "already guessed" messages in `controller/wordlebot/wordlebot.go` to improve user experience.

---
*PR created automatically by Jules for task [3307811563737886279](https://jules.google.com/task/3307811563737886279) started by @MUSTAFA-A-KHAN*