### PR TITLE
Implement Moderator Bot for Anti-Scam and Auto-Responses

### DIFF
--- a/controller/modbot/db.go
+++ b/controller/modbot/db.go
@@ -1,0 +1,234 @@
+package modbot
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// ModRuleDoc represents a single auto-responder rule
+type ModRuleDoc struct {
+	TriggerWord    string `bson:"trigger_word"`
+	ResponseType   string `bson:"response_type"` // "text", "photo", "video", "document", "audio", "animation"
+	ResponseText   string `bson:"response_text,omitempty"`
+	ResponseFileID string `bson:"response_file_id,omitempty"`
+}
+
+// ModChatSettings represents the moderator settings for a specific chat
+type ModChatSettings struct {
+	ChatID        int64                 `bson:"_id"`
+	BlockLinks    bool                  `bson:"block_links"`
+	ScamDetection bool                  `bson:"scam_detection"`
+	ScamKeywords  []string              `bson:"scam_keywords"`
+	AllowedDomains []string             `bson:"allowed_domains"`
+	Rules         map[string]ModRuleDoc `bson:"rules"` // TriggerWord as key for O(1) lookups
+}
+
+// UserViolationDoc tracks infractions for a user in a specific chat
+type UserViolationDoc struct {
+	ID        string    `bson:"_id"` // Composite key: fmt.Sprintf("%d_%d", chatID, userID)
+	ChatID    int64     `bson:"chat_id"`
+	UserID    int       `bson:"user_id"`
+	Count     int       `bson:"count"`
+	UpdatedAt time.Time `bson:"updated_at"`
+}
+
+var (
+	settingsCache = make(map[int64]*ModChatSettings)
+	settingsMutex sync.RWMutex
+	violationsCache = make(map[string]*UserViolationDoc)
+	violationsMutex sync.RWMutex
+)
+
+// GetChatSettings retrieves the settings for a chat (from cache or creates new)
+func GetChatSettings(chatID int64) *ModChatSettings {
+	settingsMutex.RLock()
+	settings, exists := settingsCache[chatID]
+	settingsMutex.RUnlock()
+
+	if exists {
+		// Return a copy to avoid data races when reading/writing concurrently
+		copySettings := &ModChatSettings{
+			ChatID:         settings.ChatID,
+			BlockLinks:     settings.BlockLinks,
+			ScamDetection:  settings.ScamDetection,
+			ScamKeywords:   append([]string(nil), settings.ScamKeywords...),
+			AllowedDomains: append([]string(nil), settings.AllowedDomains...),
+			Rules:          make(map[string]ModRuleDoc),
+		}
+		for k, v := range settings.Rules {
+			copySettings.Rules[k] = v
+		}
+		return copySettings
+	}
+
+	// Create default settings
+	newSettings := &ModChatSettings{
+		ChatID:         chatID,
+		BlockLinks:     false,
+		ScamDetection:  false,
+		ScamKeywords:   []string{"paid survey", "crypto research"}, // Default scam words
+		AllowedDomains: []string{"youtube.com", "wikipedia.org", "youtu.be"}, // Default allowed domains
+		Rules:          make(map[string]ModRuleDoc),
+	}
+
+	settingsMutex.Lock()
+	settingsCache[chatID] = newSettings
+	settingsMutex.Unlock()
+
+	copySettings := &ModChatSettings{
+		ChatID:         newSettings.ChatID,
+		BlockLinks:     newSettings.BlockLinks,
+		ScamDetection:  newSettings.ScamDetection,
+		ScamKeywords:   append([]string(nil), newSettings.ScamKeywords...),
+		AllowedDomains: append([]string(nil), newSettings.AllowedDomains...),
+		Rules:          make(map[string]ModRuleDoc),
+	}
+	return copySettings
+}
+
+// SaveChatSettings saves settings to MongoDB and updates cache
+func SaveChatSettings(client *mongo.Client, settings *ModChatSettings) {
+	settingsMutex.Lock()
+	settingsCache[settings.ChatID] = settings
+	settingsMutex.Unlock()
+
+	if client == nil {
+		return
+	}
+
+	go func() {
+		collection := client.Database("Telegram").Collection("ModSettings")
+		filter := bson.M{"_id": settings.ChatID}
+		update := bson.M{"$set": settings}
+		opts := options.Update().SetUpsert(true)
+
+		_, err := collection.UpdateOne(context.TODO(), filter, update, opts)
+		if err != nil {
+			log.Printf("Failed to save mod settings for chat %d: %v", settings.ChatID, err)
+		}
+	}()
+}
+
+func loadSettings(client *mongo.Client) {
+	if client == nil {
+		return
+	}
+
+	// Load Settings
+	collection := client.Database("Telegram").Collection("ModSettings")
+	cursor, err := collection.Find(context.TODO(), bson.M{})
+	if err != nil {
+		log.Printf("Failed to load mod settings: %v", err)
+		return
+	}
+	defer cursor.Close(context.TODO())
+
+	var results []ModChatSettings
+	if err = cursor.All(context.TODO(), &results); err != nil {
+		log.Printf("Failed to decode mod settings: %v", err)
+		return
+	}
+
+	settingsMutex.Lock()
+	for _, s := range results {
+		// Fix potentially nil maps/slices
+		if s.Rules == nil {
+			s.Rules = make(map[string]ModRuleDoc)
+		}
+		if s.ScamKeywords == nil {
+			s.ScamKeywords = []string{"paid survey", "crypto research"}
+		}
+		if s.AllowedDomains == nil {
+			s.AllowedDomains = []string{"youtube.com", "wikipedia.org", "youtu.be"}
+		}
+
+		copyS := s
+		settingsCache[s.ChatID] = &copyS
+	}
+	settingsMutex.Unlock()
+	log.Printf("Loaded %d ModBot chat settings from MongoDB", len(results))
+
+	// Load Violations
+	vCollection := client.Database("Telegram").Collection("ModViolations")
+	vCursor, err := vCollection.Find(context.TODO(), bson.M{})
+	if err != nil {
+		log.Printf("Failed to load mod violations: %v", err)
+		return
+	}
+	defer vCursor.Close(context.TODO())
+
+	var vResults []UserViolationDoc
+	if err = vCursor.All(context.TODO(), &vResults); err != nil {
+		log.Printf("Failed to decode mod violations: %v", err)
+		return
+	}
+
+	violationsMutex.Lock()
+	for _, v := range vResults {
+		copyV := v
+		violationsCache[v.ID] = &copyV
+	}
+	violationsMutex.Unlock()
+	log.Printf("Loaded %d ModBot user violations from MongoDB", len(vResults))
+}
+
+// GetUserViolations returns the number of violations a user has
+func GetUserViolations(chatID int64, userID int) int {
+	id := fmt.Sprintf("%d_%d", chatID, userID)
+
+	violationsMutex.RLock()
+	defer violationsMutex.RUnlock()
+
+	if v, exists := violationsCache[id]; exists {
+		return v.Count
+	}
+	return 0
+}
+
+// IncrementUserViolations adds 1 to a user's violation count and saves to DB
+func IncrementUserViolations(client *mongo.Client, chatID int64, userID int) int {
+	id := fmt.Sprintf("%d_%d", chatID, userID)
+
+	violationsMutex.Lock()
+	v, exists := violationsCache[id]
+	if !exists {
+		v = &UserViolationDoc{
+			ID:        id,
+			ChatID:    chatID,
+			UserID:    userID,
+			Count:     0,
+		}
+		violationsCache[id] = v
+	}
+
+	v.Count++
+	v.UpdatedAt = time.Now()
+	newCount := v.Count
+
+	// Create a copy for async saving to prevent data races
+	copyV := *v
+	violationsMutex.Unlock()
+
+	if client != nil {
+		go func() {
+			collection := client.Database("Telegram").Collection("ModViolations")
+			filter := bson.M{"_id": id}
+			update := bson.M{"$set": copyV}
+			opts := options.Update().SetUpsert(true)
+
+			_, err := collection.UpdateOne(context.TODO(), filter, update, opts)
+			if err != nil {
+				log.Printf("Failed to save mod violation for %s: %v", id, err)
+			}
+		}()
+	}
+
+	return newCount
+}

--- a/controller/modbot/filters.go
+++ b/controller/modbot/filters.go
@@ -1,0 +1,234 @@
+package modbot
+
+import (
+	"fmt"
+	"log"
+	"net/url"
+	"strings"
+	"time"
+	"regexp"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+var urlRegex = regexp.MustCompile(`(?i)(https?:\/\/[^\s]+)|(www\.[^\s]+)|([a-zA-Z0-9-]+\.[a-zA-Z]{2,}(\/[^\s]*)?)`)
+
+func handleFilters(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mongo.Client) {
+	chatID := message.Chat.ID
+	settings := GetChatSettings(chatID)
+
+	// Don't filter group admins
+	if isAdmin(bot, chatID, message.From.ID) {
+		return
+	}
+
+	text := strings.ToLower(strings.TrimSpace(message.Text))
+	if text == "" && message.Caption != "" {
+		text = strings.ToLower(strings.TrimSpace(message.Caption))
+	}
+
+	// 1. Auto-responder Rule Match (Exact Match)
+	if rule, exists := settings.Rules[text]; exists {
+		sendRuleResponse(bot, chatID, message.MessageID, rule)
+		// We don't return here just in case the message also contained a bad link
+	}
+
+	// 2. Scam Detection
+	if settings.ScamDetection {
+		for _, keyword := range settings.ScamKeywords {
+			if strings.Contains(text, keyword) {
+				handleViolation(bot, message, client, "Scam detection triggered")
+				return // Message is deleted, no need to check links
+			}
+		}
+	}
+
+	// 3. Link Blocking
+	if settings.BlockLinks {
+		urls := extractURLs(text)
+		if message.Entities != nil {
+			for _, entity := range *message.Entities {
+				if entity.Type == "url" || entity.Type == "text_link" {
+					if entity.URL != "" {
+						urls = append(urls, extractURLs(entity.URL)...)
+					}
+				}
+			}
+		}
+
+		if len(urls) > 0 {
+			for _, foundURL := range urls {
+				if !isAllowedDomain(foundURL, settings.AllowedDomains) {
+					handleViolation(bot, message, client, "Unauthorized link detected")
+					return // Message is deleted
+				}
+			}
+		}
+	}
+}
+
+func sendRuleResponse(bot *tgbotapi.BotAPI, chatID int64, replyToMessageID int, rule ModRuleDoc) {
+	var msg tgbotapi.Chattable
+
+	switch rule.ResponseType {
+	case "text":
+		textMsg := tgbotapi.NewMessage(chatID, rule.ResponseText)
+		textMsg.ReplyToMessageID = replyToMessageID
+		msg = textMsg
+	case "photo":
+		photoMsg := tgbotapi.NewPhotoShare(chatID, rule.ResponseFileID)
+		photoMsg.ReplyToMessageID = replyToMessageID
+		msg = photoMsg
+	case "video":
+		videoMsg := tgbotapi.NewVideoShare(chatID, rule.ResponseFileID)
+		videoMsg.ReplyToMessageID = replyToMessageID
+		msg = videoMsg
+	case "document":
+		docMsg := tgbotapi.NewDocumentShare(chatID, rule.ResponseFileID)
+		docMsg.ReplyToMessageID = replyToMessageID
+		msg = docMsg
+	case "animation":
+		animMsg := tgbotapi.NewAnimationShare(chatID, rule.ResponseFileID)
+		animMsg.ReplyToMessageID = replyToMessageID
+		msg = animMsg
+	default:
+		log.Printf("Unknown rule response type: %s", rule.ResponseType)
+		return
+	}
+
+	_, err := bot.Send(msg)
+	if err != nil {
+		log.Printf("Failed to send rule response: %v", err)
+	}
+}
+
+func handleViolation(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mongo.Client, reason string) {
+	chatID := message.Chat.ID
+	userID := message.From.ID
+
+	// Delete message
+	deleteMsg := tgbotapi.NewDeleteMessage(chatID, message.MessageID)
+	_, err := bot.DeleteMessage(deleteMsg)
+	if err != nil {
+		log.Printf("Failed to delete message: %v", err)
+	}
+
+	// Increment violations
+	count := IncrementUserViolations(client, chatID, userID)
+
+	// Report to group chat
+	admins, _ := bot.GetChatAdministrators(tgbotapi.ChatConfig{ChatID: chatID})
+	var adminMentions []string
+	var adminIDs []int
+	for _, admin := range admins {
+		if !admin.User.IsBot {
+			if admin.User.UserName != "" {
+				adminMentions = append(adminMentions, fmt.Sprintf("@%s", admin.User.UserName))
+			} else {
+				adminMentions = append(adminMentions, admin.User.FirstName)
+			}
+			adminIDs = append(adminIDs, admin.User.ID)
+		}
+	}
+
+	username := message.From.UserName
+	if username == "" {
+		username = message.From.FirstName
+	} else {
+		username = "@" + username
+	}
+
+	for i, adminMention := range adminMentions {
+		if adminMention == "@" {
+			// fallback if admin has no username
+			admins, _ := bot.GetChatAdministrators(tgbotapi.ChatConfig{ChatID: chatID})
+			for _, admin := range admins {
+				if admin.User.ID == adminIDs[i] {
+					adminMentions[i] = admin.User.FirstName
+					break
+				}
+			}
+		}
+	}
+
+	reportMsg := fmt.Sprintf("⚠️ Deleted message from %s for %s. (Violation %d/3)\nCc: %s",
+		username, reason, count, strings.Join(adminMentions, " "))
+	sendMessage(bot, chatID, reportMsg)
+
+	// Direct message to admins
+	dmReport := fmt.Sprintf("🚨 *Moderator Alert in Chat %d*\nUser: %s (ID: %d)\nReason: %s\nViolations: %d",
+		chatID, username, userID, reason, count)
+
+	for _, adminID := range adminIDs {
+		// Attempt to DM the admin. Note: this will fail if the admin hasn't started the bot directly.
+		dm := tgbotapi.NewMessage(int64(adminID), dmReport)
+		dm.ParseMode = "Markdown"
+		bot.Send(dm) // ignore errors for DMs
+	}
+
+	// Apply mute on 3rd violation
+	if count >= 3 {
+		muteDuration := time.Hour * 24 // 24-hour mute
+		untilTime := time.Now().Add(muteDuration).Unix()
+
+		restrictConfig := tgbotapi.RestrictChatMemberConfig{
+			ChatMemberConfig: tgbotapi.ChatMemberConfig{
+				ChatID: chatID,
+				UserID: userID,
+			},
+			UntilDate:             untilTime,
+			CanSendMessages:       new(bool),
+			CanSendMediaMessages:  new(bool),
+			CanSendOtherMessages:  new(bool),
+			CanAddWebPagePreviews: new(bool),
+		}
+
+		// Ensure pointers are false to mute
+		*restrictConfig.CanSendMessages = false
+		*restrictConfig.CanSendMediaMessages = false
+		*restrictConfig.CanSendOtherMessages = false
+		*restrictConfig.CanAddWebPagePreviews = false
+
+		_, err := bot.RestrictChatMember(restrictConfig)
+		if err != nil {
+			log.Printf("Failed to restrict user %d in chat %d: %v", userID, chatID, err)
+			sendMessage(bot, chatID, fmt.Sprintf("Failed to mute %s. Make sure I have administrator rights.", username))
+		} else {
+			sendMessage(bot, chatID, fmt.Sprintf("🔇 %s has been muted for 24 hours for repeated violations.", username))
+		}
+	}
+}
+
+func extractURLs(text string) []string {
+	if text == "" {
+		return nil
+	}
+	matches := urlRegex.FindAllString(text, -1)
+	return matches
+}
+
+func isAllowedDomain(link string, allowedDomains []string) bool {
+	// Add scheme if missing so url.Parse works reliably
+	if !strings.HasPrefix(link, "http://") && !strings.HasPrefix(link, "https://") {
+		link = "https://" + link
+	}
+
+	parsed, err := url.Parse(link)
+	if err != nil {
+		return false
+	}
+
+	host := strings.ToLower(parsed.Host)
+	// Strip www. prefix for cleaner matching
+	host = strings.TrimPrefix(host, "www.")
+
+	for _, domain := range allowedDomains {
+		domain = strings.ToLower(strings.TrimPrefix(domain, "www."))
+		if host == domain || strings.HasSuffix(host, "."+domain) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/controller/modbot/filters.go
+++ b/controller/modbot/filters.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"log"
 	"net/url"
+	"regexp"
 	"strings"
 	"time"
-	"regexp"
 
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -18,11 +18,6 @@ func handleFilters(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 	chatID := message.Chat.ID
 	settings := GetChatSettings(chatID)
 
-	// Don't filter group admins
-	if isAdmin(bot, chatID, message.From.ID) {
-		return
-	}
-
 	text := strings.ToLower(strings.TrimSpace(message.Text))
 	if text == "" && message.Caption != "" {
 		text = strings.ToLower(strings.TrimSpace(message.Caption))
@@ -32,6 +27,11 @@ func handleFilters(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 	if rule, exists := settings.Rules[text]; exists {
 		sendRuleResponse(bot, chatID, message.MessageID, rule)
 		// We don't return here just in case the message also contained a bad link
+	}
+
+	// Don't filter group admins
+	if isAdmin(bot, chatID, message.From.ID) {
+		return
 	}
 
 	// 2. Scam Detection
@@ -84,6 +84,10 @@ func sendRuleResponse(bot *tgbotapi.BotAPI, chatID int64, replyToMessageID int, 
 		videoMsg := tgbotapi.NewVideoShare(chatID, rule.ResponseFileID)
 		videoMsg.ReplyToMessageID = replyToMessageID
 		msg = videoMsg
+	case "voice":
+		voiceMsg := tgbotapi.NewVoiceShare(chatID, rule.ResponseFileID)
+		voiceMsg.ReplyToMessageID = replyToMessageID
+		msg = voiceMsg
 	case "document":
 		docMsg := tgbotapi.NewDocumentShare(chatID, rule.ResponseFileID)
 		docMsg.ReplyToMessageID = replyToMessageID
@@ -224,6 +228,10 @@ func isAllowedDomain(link string, allowedDomains []string) bool {
 	host = strings.TrimPrefix(host, "www.")
 
 	for _, domain := range allowedDomains {
+		// If the allowed entry is a full URL, match it as a prefix.
+		if strings.HasPrefix(strings.TrimSuffix(strings.ToLower(link), "/"), strings.TrimSuffix(strings.ToLower(domain), "/")) {
+			return true
+		}
 		domain = strings.ToLower(strings.TrimPrefix(domain, "www."))
 		if host == domain || strings.HasSuffix(host, "."+domain) {
 			return true

--- a/controller/modbot/handlers.go
+++ b/controller/modbot/handlers.go
@@ -1,0 +1,312 @@
+package modbot
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"time"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+type AdminCacheEntry struct {
+	Admins    map[int]bool
+	ExpiresAt time.Time
+}
+
+var (
+	adminCache = make(map[int64]AdminCacheEntry)
+	adminMutex sync.RWMutex
+)
+
+// isAdmin checks if the user is an administrator in the group.
+// It uses a temporary in-memory cache to prevent exhausting API rate limits.
+func isAdmin(bot *tgbotapi.BotAPI, chatID int64, userID int) bool {
+	if chatID > 0 { // Private chat
+		return true
+	}
+
+	// Check cache first
+	adminMutex.RLock()
+	entry, exists := adminCache[chatID]
+	adminMutex.RUnlock()
+
+	if exists && time.Now().Before(entry.ExpiresAt) {
+		return entry.Admins[userID]
+	}
+
+	// Cache miss or expired, fetch from API
+	admins, err := bot.GetChatAdministrators(tgbotapi.ChatConfig{ChatID: chatID})
+	if err != nil {
+		log.Printf("Failed to get chat administrators for chat %d: %v", chatID, err)
+		return false
+	}
+
+	newAdmins := make(map[int]bool)
+	for _, admin := range admins {
+		newAdmins[admin.User.ID] = true
+	}
+
+	// Cache for 5 minutes
+	adminMutex.Lock()
+	adminCache[chatID] = AdminCacheEntry{
+		Admins:    newAdmins,
+		ExpiresAt: time.Now().Add(5 * time.Minute),
+	}
+	adminMutex.Unlock()
+
+	return newAdmins[userID]
+}
+
+func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, dbClient interface{}) {
+	client := dbClient.(*mongo.Client)
+
+	if message.IsCommand() {
+		handleCommand(bot, message, client)
+		return
+	}
+
+	// Handle regular messages for filtering and auto-responder
+	handleFilters(bot, message, client)
+}
+
+func handleCommand(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mongo.Client) {
+	chatID := message.Chat.ID
+	userID := message.From.ID
+
+	// Admins only
+	if !isAdmin(bot, chatID, userID) {
+		if message.Command() == "addrule" || message.Command() == "delrule" || message.Command() == "modsettings" {
+			sendMessage(bot, chatID, "You must be an admin to use this command.")
+		}
+		return
+	}
+
+	settings := GetChatSettings(chatID)
+
+	switch message.Command() {
+	case "addrule":
+		// Usage: /addrule <trigger_word> <response_text> OR /addrule <trigger_word> (as a reply to media)
+		args := message.CommandArguments()
+		parts := strings.SplitN(args, " ", 2)
+
+		if len(parts) == 0 || parts[0] == "" {
+			sendMessage(bot, chatID, "Usage:\n- `/addrule <word> <response>`\n- `/addrule <word>` (replying to a file/image)")
+			return
+		}
+
+		trigger := strings.ToLower(strings.TrimSpace(parts[0]))
+		rule := ModRuleDoc{TriggerWord: trigger}
+
+		if message.ReplyToMessage != nil {
+			// Check if it's a media reply
+			if message.ReplyToMessage.Photo != nil && len(*message.ReplyToMessage.Photo) > 0 {
+				photos := *message.ReplyToMessage.Photo
+				rule.ResponseType = "photo"
+				rule.ResponseFileID = photos[len(photos)-1].FileID
+			} else if message.ReplyToMessage.Video != nil {
+				rule.ResponseType = "video"
+				rule.ResponseFileID = message.ReplyToMessage.Video.FileID
+			} else if message.ReplyToMessage.Document != nil {
+				rule.ResponseType = "document"
+				rule.ResponseFileID = message.ReplyToMessage.Document.FileID
+			} else if message.ReplyToMessage.Animation != nil {
+				rule.ResponseType = "animation"
+				rule.ResponseFileID = message.ReplyToMessage.Animation.FileID
+			} else if message.ReplyToMessage.Text != "" {
+				rule.ResponseType = "text"
+				rule.ResponseText = message.ReplyToMessage.Text
+			} else {
+				sendMessage(bot, chatID, "Unsupported media type for rule.")
+				return
+			}
+		} else if len(parts) > 1 {
+			// Text rule
+			rule.ResponseType = "text"
+			rule.ResponseText = strings.TrimSpace(parts[1])
+		} else {
+			sendMessage(bot, chatID, "Please provide a response text or reply to a message with the command.")
+			return
+		}
+
+		settings.Rules[trigger] = rule
+		SaveChatSettings(client, settings)
+		sendMessage(bot, chatID, fmt.Sprintf("✅ Rule added for keyword: `%s`", trigger))
+
+	case "delrule":
+		args := strings.ToLower(strings.TrimSpace(message.CommandArguments()))
+		if args == "" {
+			sendMessage(bot, chatID, "Usage: `/delrule <word>`")
+			return
+		}
+
+		if _, exists := settings.Rules[args]; exists {
+			delete(settings.Rules, args)
+			SaveChatSettings(client, settings)
+			sendMessage(bot, chatID, fmt.Sprintf("✅ Rule removed for keyword: `%s`", args))
+		} else {
+			sendMessage(bot, chatID, fmt.Sprintf("Rule not found for: `%s`", args))
+		}
+
+	case "addscamword":
+		args := strings.ToLower(strings.TrimSpace(message.CommandArguments()))
+		if args == "" {
+			sendMessage(bot, chatID, "Usage: `/addscamword <phrase>`")
+			return
+		}
+
+		// Check if already exists
+		for _, w := range settings.ScamKeywords {
+			if w == args {
+				sendMessage(bot, chatID, "Phrase is already in the scam filter.")
+				return
+			}
+		}
+
+		settings.ScamKeywords = append(settings.ScamKeywords, args)
+		SaveChatSettings(client, settings)
+		sendMessage(bot, chatID, fmt.Sprintf("✅ Added `%s` to scam filter.", args))
+
+	case "delscamword":
+		args := strings.ToLower(strings.TrimSpace(message.CommandArguments()))
+		if args == "" {
+			sendMessage(bot, chatID, "Usage: `/delscamword <phrase>`")
+			return
+		}
+
+		found := false
+		var newWords []string
+		for _, w := range settings.ScamKeywords {
+			if w == args {
+				found = true
+			} else {
+				newWords = append(newWords, w)
+			}
+		}
+
+		if found {
+			settings.ScamKeywords = newWords
+			SaveChatSettings(client, settings)
+			sendMessage(bot, chatID, fmt.Sprintf("✅ Removed `%s` from scam filter.", args))
+		} else {
+			sendMessage(bot, chatID, "Phrase not found in the scam filter.")
+		}
+
+	case "adddomain":
+		args := strings.ToLower(strings.TrimSpace(message.CommandArguments()))
+		if args == "" {
+			sendMessage(bot, chatID, "Usage: `/adddomain <domain>` (e.g. google.com)")
+			return
+		}
+
+		for _, d := range settings.AllowedDomains {
+			if d == args {
+				sendMessage(bot, chatID, "Domain is already allowed.")
+				return
+			}
+		}
+
+		settings.AllowedDomains = append(settings.AllowedDomains, args)
+		SaveChatSettings(client, settings)
+		sendMessage(bot, chatID, fmt.Sprintf("✅ Allowed domain `%s`.", args))
+
+	case "deldomain":
+		args := strings.ToLower(strings.TrimSpace(message.CommandArguments()))
+		if args == "" {
+			sendMessage(bot, chatID, "Usage: `/deldomain <domain>`")
+			return
+		}
+
+		found := false
+		var newDomains []string
+		for _, d := range settings.AllowedDomains {
+			if d == args {
+				found = true
+			} else {
+				newDomains = append(newDomains, d)
+			}
+		}
+
+		if found {
+			settings.AllowedDomains = newDomains
+			SaveChatSettings(client, settings)
+			sendMessage(bot, chatID, fmt.Sprintf("✅ Removed `%s` from allowed domains.", args))
+		} else {
+			sendMessage(bot, chatID, "Domain not found in allowed list.")
+		}
+
+	case "modsettings":
+		sendSettingsMenu(bot, chatID, settings)
+	}
+}
+
+func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery, dbClient interface{}) {
+	client := dbClient.(*mongo.Client)
+	chatID := callback.Message.Chat.ID
+	userID := callback.From.ID
+
+	if !isAdmin(bot, chatID, userID) {
+		bot.AnswerCallbackQuery(tgbotapi.NewCallbackWithAlert(callback.ID, "You must be an admin to configure settings."))
+		return
+	}
+
+	settings := GetChatSettings(chatID)
+
+	switch callback.Data {
+	case "toggle_block_links":
+		settings.BlockLinks = !settings.BlockLinks
+		SaveChatSettings(client, settings)
+
+	case "toggle_scam_detection":
+		settings.ScamDetection = !settings.ScamDetection
+		SaveChatSettings(client, settings)
+	}
+
+	// Update the menu
+	updateSettingsMenu(bot, callback.Message, settings)
+	bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Settings updated."))
+}
+
+func sendSettingsMenu(bot *tgbotapi.BotAPI, chatID int64, settings *ModChatSettings) {
+	msg := tgbotapi.NewMessage(chatID, "⚙️ *Moderator Bot Settings*")
+	msg.ParseMode = "Markdown"
+	msg.ReplyMarkup = getSettingsKeyboard(settings)
+	bot.Send(msg)
+}
+
+func updateSettingsMenu(bot *tgbotapi.BotAPI, msg *tgbotapi.Message, settings *ModChatSettings) {
+	editMsg := tgbotapi.NewEditMessageReplyMarkup(msg.Chat.ID, msg.MessageID, getSettingsKeyboard(settings))
+	bot.Send(editMsg)
+}
+
+func getSettingsKeyboard(settings *ModChatSettings) tgbotapi.InlineKeyboardMarkup {
+	linkText := "🔴 Block Links: OFF"
+	if settings.BlockLinks {
+		linkText = "🟢 Block Links: ON"
+	}
+
+	scamText := "🔴 Scam Detection: OFF"
+	if settings.ScamDetection {
+		scamText = "🟢 Scam Detection: ON"
+	}
+
+	return tgbotapi.NewInlineKeyboardMarkup(
+		tgbotapi.NewInlineKeyboardRow(
+			tgbotapi.NewInlineKeyboardButtonData(linkText, "toggle_block_links"),
+		),
+		tgbotapi.NewInlineKeyboardRow(
+			tgbotapi.NewInlineKeyboardButtonData(scamText, "toggle_scam_detection"),
+		),
+	)
+}
+
+func sendMessage(bot *tgbotapi.BotAPI, chatID int64, text string) {
+	msg := tgbotapi.NewMessage(chatID, text)
+	msg.ParseMode = "Markdown"
+	_, err := bot.Send(msg)
+	if err != nil {
+		log.Printf("Failed to send message: %v", err)
+	}
+}

--- a/controller/modbot/handlers.go
+++ b/controller/modbot/handlers.go
@@ -109,6 +109,10 @@ func handleCommand(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 			} else if message.ReplyToMessage.Video != nil {
 				rule.ResponseType = "video"
 				rule.ResponseFileID = message.ReplyToMessage.Video.FileID
+
+			} else if message.ReplyToMessage.Voice != nil {
+				rule.ResponseType = "voice"
+				rule.ResponseFileID = message.ReplyToMessage.Voice.FileID
 			} else if message.ReplyToMessage.Document != nil {
 				rule.ResponseType = "document"
 				rule.ResponseFileID = message.ReplyToMessage.Document.FileID

--- a/controller/modbot/modbot.go
+++ b/controller/modbot/modbot.go
@@ -1,0 +1,47 @@
+package modbot
+
+import (
+	"log"
+	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/repository"
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+)
+
+// StartModBot initializes and starts the moderator bot
+func StartModBot(token string) error {
+	bot, err := tgbotapi.NewBotAPI(token)
+	if err != nil {
+		return err
+	}
+
+	bot.Debug = true
+	log.Printf("ModBot authorized on account %s", bot.Self.UserName)
+
+	client := repository.DbManager()
+	if client == nil {
+		log.Fatal("Failed to connect to MongoDB for ModBot")
+	}
+
+	// Load settings from DB
+	loadSettings(client)
+
+	u := tgbotapi.NewUpdate(0)
+	u.Timeout = 60
+
+	updates, err := bot.GetUpdatesChan(u)
+	if err != nil {
+		return err
+	}
+
+	for update := range updates {
+		if update.Message != nil {
+			go handleMessage(bot, update.Message, client)
+		} else if update.EditedMessage != nil {
+			// Apply filters to edited messages to prevent filter bypassing
+			go handleFilters(bot, update.EditedMessage, client)
+		} else if update.CallbackQuery != nil {
+			go handleCallbackQuery(bot, update.CallbackQuery, client)
+		}
+	}
+
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	categorybot "github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/categoryBot"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/fontbot"
 	instagrambot "github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/instagramBot"
+	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/modbot"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/translator"
 )
 
@@ -19,11 +20,12 @@ func main() {
 	categorycharades := CategoryVariable
 	instagram := "7995903003:AAEcvtxq1Swak9W_uuMwQ-Jv-YXKOp_i-pw"
 	fontbotToken := "YOUR_FONT_BOT_TOKEN_HERE" // Replace with your actual font bot token
+	modbotToken := os.Getenv("MOD_BOT_TOKEN") // Token for the moderator bot
 	// WaitGroup to wait for all goroutines to finish
 	var wg sync.WaitGroup
 
-	// Add five tasks to the WaitGroup
-	wg.Add(5)
+	// Add six tasks to the WaitGroup
+	wg.Add(6)
 
 	// Start bots in separate goroutines
 	go runWordBot(charades, &wg)
@@ -31,6 +33,7 @@ func main() {
 	go runInstagramBot(instagram, &wg)
 	go runTranslatorBot(&wg)
 	go runFontBot(fontbotToken, &wg)
+	go runModBot(modbotToken, &wg)
 
 	// Wait for goroutines to complete
 	wg.Wait()
@@ -90,5 +93,21 @@ func runFontBot(botToken string, wg *sync.WaitGroup) {
 	err := fontbot.StartFormatBot(botToken)
 	if err != nil {
 		log.Printf("Error starting font bot with token %s: %v\n", botToken, err)
+	}
+}
+
+// Function to start the mod bot with error handling
+func runModBot(botToken string, wg *sync.WaitGroup) {
+	defer wg.Done() // Decrement the wait group counter when this goroutine completes
+
+	// Skip starting if token is empty to avoid panic locally
+	if botToken == "" {
+		log.Println("MOD_BOT_TOKEN is empty. Skipping ModBot startup.")
+		return
+	}
+
+	err := modbot.StartModBot(botToken)
+	if err != nil {
+		log.Printf("Error starting mod bot with token %s: %v\n", botToken, err)
 	}
 }


### PR DESCRIPTION
This PR introduces a brand new standalone Telegram moderator bot designed to enforce chat rules effectively. 

### Key Features
1. **Auto-Responder System:** Admins can dynamically configure exact-match triggers using `/addrule` and `/delrule`. The system natively supports replying to files to save media identifiers, allowing the bot to respond with photos, videos, or documents directly.
2. **Scam Detection & Link Blocking:** The bot continuously monitors non-admin traffic for pre-defined scam keywords (configurable via `/addscamword`) and unauthorized links. Safe links can be added via `/adddomain`.
3. **Automated Enforcement:** Messages violating the rules are instantly deleted. The bot tracks user violations in MongoDB. Upon reaching 3 strikes, the bot automatically applies a 24-hour mute (`bot.RestrictChatMember`). Every moderation action triggers a report mentioning the group admins, and optionally sends a DM to the admins for persistent records.

The bot runs concurrently with the existing bots inside `main.go` using a new `MOD_BOT_TOKEN` environment variable. To avoid crashing local environments that don't need the moderator bot, the startup gracefully skips initialization if the token is empty.

---
*PR created automatically by Jules for task [17782816106014413742](https://jules.google.com/task/17782816106014413742) started by @MUSTAFA-A-KHAN*