### PR TITLE
feat: enhance modbot rule creation accessibility

### DIFF
--- a/controller/modbot/caption_patch.go
+++ b/controller/modbot/caption_patch.go
@@ -1,0 +1,34 @@
+package modbot
+
+import (
+	"strings"
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+)
+
+// ExtractCommandFromCaption extracts a command and its arguments from a message caption if it exists.
+func ExtractCommandFromCaption(message *tgbotapi.Message) (isCommand bool, command string, args string) {
+	if message.Caption == "" {
+		return false, "", ""
+	}
+
+	// Because CaptionEntities isn't supported in this specific v1.0.1 fork,
+	// we will manually parse the caption to see if it starts with a command.
+	if strings.HasPrefix(message.Caption, "/") {
+		parts := strings.SplitN(message.Caption, " ", 2)
+		cmd := parts[0][1:] // Remove leading slash
+
+		// Remove bot username if present (e.g., /addrule@BotName)
+		if idx := strings.Index(cmd, "@"); idx != -1 {
+			cmd = cmd[:idx]
+		}
+
+		arguments := ""
+		if len(parts) > 1 {
+			arguments = strings.TrimSpace(parts[1])
+		}
+
+		return true, cmd, arguments
+	}
+
+	return false, "", ""
+}

--- a/controller/modbot/filters.go
+++ b/controller/modbot/filters.go
@@ -16,11 +16,59 @@ var urlRegex = regexp.MustCompile(`(?i)(https?:\/\/[^\s]+)|(www\.[^\s]+)|([a-zA-
 
 func handleFilters(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mongo.Client) {
 	chatID := message.Chat.ID
+	userID := message.From.ID
 	settings := GetChatSettings(chatID)
 
 	text := strings.ToLower(strings.TrimSpace(message.Text))
 	if text == "" && message.Caption != "" {
 		text = strings.ToLower(strings.TrimSpace(message.Caption))
+	}
+
+	// BOT MENTION OR REPLY MENU (Admins only)
+	if isAdmin(bot, chatID, userID) && message.ReplyToMessage != nil {
+		isBotMentioned := false
+		botUsername := bot.Self.UserName
+
+		// Check if the reply text mentions the bot
+		if strings.Contains(text, "@"+strings.ToLower(botUsername)) {
+			isBotMentioned = true
+		}
+
+		if isBotMentioned {
+			SetPendingRuleMessage(chatID, userID, message.ReplyToMessage)
+
+			// Show inline menu for this message
+			msg := tgbotapi.NewMessage(chatID, "What would you like to do with the replied message?")
+			msg.ReplyToMessageID = message.MessageID
+
+			var keyboard [][]tgbotapi.InlineKeyboardButton
+
+			// Always allow adding as a rule response
+			keyboard = append(keyboard, tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("📝 Add as Rule Response", "menu_add_rule"),
+			))
+
+			// If it's text, we can also add it as a scam keyword
+			if message.ReplyToMessage.Text != "" {
+				keyboard = append(keyboard, tgbotapi.NewInlineKeyboardRow(
+					tgbotapi.NewInlineKeyboardButtonData("🚫 Add as Scam Keyword", "menu_add_scam"),
+				))
+			}
+
+			keyboard = append(keyboard, tgbotapi.NewInlineKeyboardRow(
+				tgbotapi.NewInlineKeyboardButtonData("❌ Cancel", "menu_cancel"),
+			))
+
+			msg.ReplyMarkup = tgbotapi.NewInlineKeyboardMarkup(keyboard...)
+			bot.Send(msg)
+			return
+		}
+	}
+
+	// INTERACTIVE FLOW HANDLING
+	if state, exists := GetInteractiveState(chatID, userID); exists {
+		handleInteractiveState(bot, message, client, settings, state)
+		return
 	}
 
 	// 1. Auto-responder Rule Match (Exact Match)
@@ -239,4 +287,89 @@ func isAllowedDomain(link string, allowedDomains []string) bool {
 	}
 
 	return false
+}
+
+func handleInteractiveState(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mongo.Client, settings *ModChatSettings, state AddRuleState) {
+	chatID := message.Chat.ID
+	userID := message.From.ID
+
+	if message.Text == "/cancel" {
+		ClearInteractiveState(chatID, userID)
+		sendMessage(bot, chatID, "Rule creation cancelled.")
+		return
+	}
+
+	if state.Step == 1 {
+		// Expecting trigger word
+		if message.Text == "" {
+			sendMessage(bot, chatID, "Please send a text keyword to trigger the rule, or type /cancel to abort.")
+			return
+		}
+
+		trigger := strings.ToLower(strings.TrimSpace(message.Text))
+		SetInteractiveState(chatID, userID, AddRuleState{Step: 2, TriggerWord: trigger})
+
+		msg := tgbotapi.NewMessage(chatID, fmt.Sprintf("Great! Now send the text or media that should be sent when someone says `%s`.", trigger))
+		msg.ParseMode = "Markdown"
+		msg.ReplyMarkup = tgbotapi.ForceReply{ForceReply: true, Selective: true}
+		bot.Send(msg)
+		return
+	}
+
+	if state.Step == 2 || state.Step == 3 {
+
+		var msgToProcess *tgbotapi.Message
+
+		if state.Step == 2 {
+			msgToProcess = message
+		} else { // Step 3
+			// We already have the response from the pending rule message
+			// And the current message contains the trigger word
+			if message.Text == "" {
+				sendMessage(bot, chatID, "Please send a text keyword to trigger the rule, or type /cancel to abort.")
+				return
+			}
+			state.TriggerWord = strings.ToLower(strings.TrimSpace(message.Text))
+
+			pendingMsg, exists := GetAndClearPendingRuleMessage(chatID, userID)
+			if !exists || pendingMsg == nil {
+				sendMessage(bot, chatID, "Error: The pending message was lost. Please try again.")
+				ClearInteractiveState(chatID, userID)
+				return
+			}
+			msgToProcess = pendingMsg
+		}
+
+		// Expecting response
+		rule := ModRuleDoc{TriggerWord: state.TriggerWord}
+
+		if msgToProcess.Photo != nil && len(*msgToProcess.Photo) > 0 {
+			photos := *msgToProcess.Photo
+			rule.ResponseType = "photo"
+			rule.ResponseFileID = photos[len(photos)-1].FileID
+		} else if msgToProcess.Video != nil {
+			rule.ResponseType = "video"
+			rule.ResponseFileID = msgToProcess.Video.FileID
+		} else if msgToProcess.Voice != nil {
+			rule.ResponseType = "voice"
+			rule.ResponseFileID = msgToProcess.Voice.FileID
+		} else if msgToProcess.Document != nil {
+			rule.ResponseType = "document"
+			rule.ResponseFileID = msgToProcess.Document.FileID
+		} else if msgToProcess.Animation != nil {
+			rule.ResponseType = "animation"
+			rule.ResponseFileID = msgToProcess.Animation.FileID
+		} else if msgToProcess.Text != "" {
+			rule.ResponseType = "text"
+			rule.ResponseText = msgToProcess.Text
+		} else {
+			sendMessage(bot, chatID, "Unsupported media type. Please send text, photo, video, document, voice, or animation.")
+			return
+		}
+
+		settings.Rules[state.TriggerWord] = rule
+		SaveChatSettings(client, settings)
+		ClearInteractiveState(chatID, userID)
+		sendMessage(bot, chatID, fmt.Sprintf("✅ Rule added for keyword: `%s`", state.TriggerWord))
+	}
 }

--- a/controller/modbot/handlers.go
+++ b/controller/modbot/handlers.go
@@ -68,6 +68,17 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, dbClient int
 		return
 	}
 
+	// Also handle commands in captions
+	if message.Caption != "" {
+		isCmd, cmd, args := ExtractCommandFromCaption(message)
+		if isCmd {
+			// We can slightly mutate the message so handleCommand works
+			message.Text = "/" + cmd + " " + args
+			handleCommand(bot, message, client)
+			return
+		}
+	}
+
 	// Handle regular messages for filtering and auto-responder
 	handleFilters(bot, message, client)
 }
@@ -98,6 +109,17 @@ func handleCommand(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 		}
 
 		trigger := strings.ToLower(strings.TrimSpace(parts[0]))
+
+		// INTERACTIVE FLOW INIT
+		if trigger == "" && message.ReplyToMessage == nil && message.Caption == "" {
+			SetInteractiveState(chatID, userID, AddRuleState{Step: 1})
+
+			msg := tgbotapi.NewMessage(chatID, "Please send the keyword for the new rule.")
+			msg.ReplyMarkup = tgbotapi.ForceReply{ForceReply: true, Selective: true}
+			bot.Send(msg)
+			return
+		}
+
 		rule := ModRuleDoc{TriggerWord: trigger}
 
 		if message.ReplyToMessage != nil {
@@ -126,12 +148,40 @@ func handleCommand(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 				sendMessage(bot, chatID, "Unsupported media type for rule.")
 				return
 			}
+		} else if message.Caption != "" {
+			// Support direct caption rule addition without replying
+			if message.Photo != nil && len(*message.Photo) > 0 {
+				photos := *message.Photo
+				rule.ResponseType = "photo"
+				rule.ResponseFileID = photos[len(photos)-1].FileID
+			} else if message.Video != nil {
+				rule.ResponseType = "video"
+				rule.ResponseFileID = message.Video.FileID
+			} else if message.Voice != nil {
+				rule.ResponseType = "voice"
+				rule.ResponseFileID = message.Voice.FileID
+			} else if message.Document != nil {
+				rule.ResponseType = "document"
+				rule.ResponseFileID = message.Document.FileID
+			} else if message.Animation != nil {
+				rule.ResponseType = "animation"
+				rule.ResponseFileID = message.Animation.FileID
+			} else {
+				sendMessage(bot, chatID, "Unsupported media type for rule in caption.")
+				return
+			}
 		} else if len(parts) > 1 {
 			// Text rule
 			rule.ResponseType = "text"
 			rule.ResponseText = strings.TrimSpace(parts[1])
 		} else {
-			sendMessage(bot, chatID, "Please provide a response text or reply to a message with the command.")
+			// They provided a trigger, but no response or reply
+			SetInteractiveState(chatID, userID, AddRuleState{Step: 2, TriggerWord: trigger})
+
+			msg := tgbotapi.NewMessage(chatID, fmt.Sprintf("Great! Now send the text or media that should be sent when someone says `%s`.", trigger))
+			msg.ParseMode = "Markdown"
+			msg.ReplyMarkup = tgbotapi.ForceReply{ForceReply: true, Selective: true}
+			bot.Send(msg)
 			return
 		}
 
@@ -262,15 +312,59 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 	case "toggle_block_links":
 		settings.BlockLinks = !settings.BlockLinks
 		SaveChatSettings(client, settings)
+		updateSettingsMenu(bot, callback.Message, settings)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Settings updated."))
 
 	case "toggle_scam_detection":
 		settings.ScamDetection = !settings.ScamDetection
 		SaveChatSettings(client, settings)
-	}
+		updateSettingsMenu(bot, callback.Message, settings)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Settings updated."))
 
-	// Update the menu
-	updateSettingsMenu(bot, callback.Message, settings)
-	bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Settings updated."))
+	case "menu_add_rule":
+		// Enter the interactive flow but we already have the response
+		SetInteractiveState(chatID, userID, AddRuleState{Step: 3}) // Step 3 means we are just waiting for the trigger word
+
+		msg := tgbotapi.NewMessage(chatID, "What keyword should trigger this rule?")
+		msg.ReplyMarkup = tgbotapi.ForceReply{ForceReply: true, Selective: true}
+		bot.Send(msg)
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
+
+		// Delete the inline menu
+		delMsg := tgbotapi.NewDeleteMessage(chatID, callback.Message.MessageID)
+		bot.Send(delMsg)
+
+	case "menu_add_scam":
+		if pendingMsg, ok := GetAndClearPendingRuleMessage(chatID, userID); ok && pendingMsg.Text != "" {
+			keyword := strings.ToLower(strings.TrimSpace(pendingMsg.Text))
+
+			// Check if already exists
+			exists := false
+			for _, w := range settings.ScamKeywords {
+				if w == keyword {
+					exists = true
+					break
+				}
+			}
+
+			if !exists {
+				settings.ScamKeywords = append(settings.ScamKeywords, keyword)
+				SaveChatSettings(client, settings)
+				sendMessage(bot, chatID, fmt.Sprintf("✅ Added `%s` to scam filter.", keyword))
+			} else {
+				sendMessage(bot, chatID, "Phrase is already in the scam filter.")
+			}
+		}
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, ""))
+		delMsg := tgbotapi.NewDeleteMessage(chatID, callback.Message.MessageID)
+		bot.Send(delMsg)
+
+	case "menu_cancel":
+		GetAndClearPendingRuleMessage(chatID, userID) // Clear the pending message
+		bot.AnswerCallbackQuery(tgbotapi.NewCallback(callback.ID, "Cancelled"))
+		delMsg := tgbotapi.NewDeleteMessage(chatID, callback.Message.MessageID)
+		bot.Send(delMsg)
+	}
 }
 
 func sendSettingsMenu(bot *tgbotapi.BotAPI, chatID int64, settings *ModChatSettings) {

--- a/controller/modbot/state.go
+++ b/controller/modbot/state.go
@@ -1,0 +1,87 @@
+package modbot
+
+import (
+	"sync"
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+)
+
+// AddRuleState represents the current state of a user's interactive addrule session
+type AddRuleState struct {
+	Step        int    // 1: Waiting for trigger, 2: Waiting for response
+	TriggerWord string // Store the trigger word between steps
+}
+
+var (
+	interactiveState     = make(map[int64]map[int]AddRuleState) // ChatID -> UserID -> State
+	interactiveStateLock sync.RWMutex
+)
+
+// GetInteractiveState gets the current state for a user in a chat
+func GetInteractiveState(chatID int64, userID int) (AddRuleState, bool) {
+	interactiveStateLock.RLock()
+	defer interactiveStateLock.RUnlock()
+
+	if chatMap, exists := interactiveState[chatID]; exists {
+		state, userExists := chatMap[userID]
+		return state, userExists
+	}
+	return AddRuleState{}, false
+}
+
+// SetInteractiveState sets the current state for a user in a chat
+func SetInteractiveState(chatID int64, userID int, state AddRuleState) {
+	interactiveStateLock.Lock()
+	defer interactiveStateLock.Unlock()
+
+	if _, exists := interactiveState[chatID]; !exists {
+		interactiveState[chatID] = make(map[int]AddRuleState)
+	}
+	interactiveState[chatID][userID] = state
+}
+
+// ClearInteractiveState removes the state for a user in a chat
+func ClearInteractiveState(chatID int64, userID int) {
+	interactiveStateLock.Lock()
+	defer interactiveStateLock.Unlock()
+
+	if chatMap, exists := interactiveState[chatID]; exists {
+		delete(chatMap, userID)
+		if len(chatMap) == 0 {
+			delete(interactiveState, chatID)
+		}
+	}
+}
+
+// We can store a reference to the message the admin wants to add a rule for.
+var (
+	pendingRuleMessage     = make(map[int64]map[int]*tgbotapi.Message) // ChatID -> UserID -> Message
+	pendingRuleMessageLock sync.RWMutex
+)
+
+// SetPendingRuleMessage stores a message that an admin wants to use for a rule response
+func SetPendingRuleMessage(chatID int64, userID int, msg *tgbotapi.Message) {
+	pendingRuleMessageLock.Lock()
+	defer pendingRuleMessageLock.Unlock()
+
+	if _, exists := pendingRuleMessage[chatID]; !exists {
+		pendingRuleMessage[chatID] = make(map[int]*tgbotapi.Message)
+	}
+	pendingRuleMessage[chatID][userID] = msg
+}
+
+// GetAndClearPendingRuleMessage retrieves and clears the pending message
+func GetAndClearPendingRuleMessage(chatID int64, userID int) (*tgbotapi.Message, bool) {
+	pendingRuleMessageLock.Lock()
+	defer pendingRuleMessageLock.Unlock()
+
+	if chatMap, exists := pendingRuleMessage[chatID]; exists {
+		if msg, userExists := chatMap[userID]; userExists {
+			delete(chatMap, userID)
+			if len(chatMap) == 0 {
+				delete(pendingRuleMessage, chatID)
+			}
+			return msg, true
+		}
+	}
+	return nil, false
+}


### PR DESCRIPTION
This PR implements several enhancements to make adding rules and scam keywords more accessible for group admins in `modbot`:

1. **Caption Parsing**: Users can now upload media with the caption `/addrule [keyword]` directly, skipping the need to reply to the media with a separate message.
2. **Interactive Flow**: Typing `/addrule` without arguments or replies initiates a conversational flow where the bot asks for the trigger keyword, and then asks for the text/media response, using Telegram's ForceReply.
3. **Bot Mention Context Menu**: If an admin replies to a message and mentions the bot's username (e.g. `@botname`), the bot sends an inline keyboard giving the admin the option to instantly "Add as Rule Response" or "Add as Scam Keyword". If "Add as Rule Response" is selected, the bot asks for the trigger word and associates it with the replied message.

---
*PR created automatically by Jules for task [9547576834420587802](https://jules.google.com/task/9547576834420587802) started by @MUSTAFA-A-KHAN*