### PR TITLE
feat: allow plural guesses for category game

### DIFF
--- a/controller/bot.go
+++ b/controller/bot.go
@@ -674,7 +674,7 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 		word := chatState.Word
 		chatState.RUnlock()
 
-		if service.NormalizeAndCompare(message.Text, word) && message.From.ID == chatState.User {
+		if service.NormalizeAndComparePlural(message.Text, word) && message.From.ID == chatState.User {
 			view.SendMessage(bot, chatID, fmt.Sprintf("🦉 Correct! %s ! You guessed the word '%s' correctly!", telegramReactions[7], word))
 			view.ReactToMessage(bot.Token, chatID, message.MessageID, telegramReactions[17], true)
 			view.ReactToMessage(bot.Token, chatID, message.MessageID, "⚡", true)
@@ -1068,7 +1068,7 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 		leader := chatState.Leader
 		chatState.RUnlock()
 
-		if user != 0 && service.NormalizeAndCompare(message.Text, word) && message.From.ID != user {
+		if user != 0 && service.NormalizeAndComparePlural(message.Text, word) && message.From.ID != user {
 			chatState.reset(chatID)
 
 			// THE CHARACTER UPGRADE:
@@ -2037,7 +2037,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		chatState.RLock()
 		word := chatState.Word
 		chatState.RUnlock()
-		if service.NormalizeAndCompare(callback.Message.Text, word) {
+		if service.NormalizeAndComparePlural(callback.Message.Text, word) {
 			buttons := createSingleButtonKeyboard("🌟 Claim Leadership 🙋", "explain")
 			view.SendMessageWithButtons(bot, callback.Message.Chat.ID, fmt.Sprintf("%s! %s guessed the word correctly.", telegramReactions[0], callback.From.FirstName), buttons)
 			chatState.reset(chatID)

--- a/controller/categoryBot/categoryBot.go
+++ b/controller/categoryBot/categoryBot.go
@@ -786,7 +786,7 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 		word := chatState.Word
 		chatState.RUnlock()
 
-		if service.NormalizeAndCompare(message.Text, word) && message.From.ID == chatState.User {
+		if service.NormalizeAndComparePlural(message.Text, word) && message.From.ID == chatState.User {
 			view.SendMessage(bot, chatID, fmt.Sprintf("%s ! You guessed the word '%s' correctly!", telegramReactions[7], word))
 			view.ReactToMessage(bot.Token, chatID, message.MessageID, telegramReactions[rand.Intn(8)+13], true)
 			view.ReactToMessage(bot.Token, chatID, message.MessageID, telegramReactions[rand.Intn(8)+13], true)
@@ -1424,7 +1424,7 @@ func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mong
 		leader := chatState.Leader
 		chatState.RUnlock()
 
-		if user != 0 && service.NormalizeAndCompare(message.Text, word) && message.From.ID != user {
+		if user != 0 && service.NormalizeAndComparePlural(message.Text, word) && message.From.ID != user {
 			chatState.reset(chatID)
 			buttons := createSingleButtonKeyboard("🌟 Claim Leadership 🙋", "explain")
 			view.SendMessageWithButtons(bot, message.Chat.ID, fmt.Sprintf("%s! %s guessed the word %s.\n /word", telegramReactions[7], message.From.FirstName, word), buttons)
@@ -2427,7 +2427,7 @@ func handleCallbackQuery(bot *tgbotapi.BotAPI, callback *tgbotapi.CallbackQuery,
 		chatState.RLock()
 		word := chatState.Word
 		chatState.RUnlock()
-		if service.NormalizeAndCompare(callback.Message.Text, word) {
+		if service.NormalizeAndComparePlural(callback.Message.Text, word) {
 			buttons := createSingleButtonKeyboard("🌟 Claim Leadership 🙋", "explain")
 			view.SendMessageWithButtons(bot, callback.Message.Chat.ID, fmt.Sprintf("%s! %s guessed the word correctly.", telegramReactions[0], callback.From.FirstName), buttons)
 			chatState.reset(chatID)

--- a/service/StringUtilsService.go
+++ b/service/StringUtilsService.go
@@ -6,76 +6,103 @@ import (
 	"unicode/utf8"
 )
 
-// normalizeAndCompare normalizes both strings and compares them
-func NormalizeAndCompare(str1, str2 string) bool {
-	normalizeString := func(s string) string {
-		var b strings.Builder
-		b.Grow(len(s))
-		lastWasSpace := false
+func normalizeString(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	lastWasSpace := false
 
-		for i := 0; i < len(s); {
-			c := s[i]
-			// ⚡ Bolt Optimization: ASCII fast path bypasses implicit rune decoding overhead and unicode package function calls
-			// Reduces average execution time by >50% (from ~1700ns to ~700ns)
-			if c < utf8.RuneSelf {
-				i++
-				isLetter := (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
-				isDigit := c >= '0' && c <= '9'
-				isWord := isLetter || isDigit || c == '_'
-				isSpace := c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\v' || c == '\f'
+	for i := 0; i < len(s); {
+		c := s[i]
+		// ⚡ Bolt Optimization: ASCII fast path bypasses implicit rune decoding overhead and unicode package function calls
+		// Reduces average execution time by >50% (from ~1700ns to ~700ns)
+		if c < utf8.RuneSelf {
+			i++
+			isLetter := (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+			isDigit := c >= '0' && c <= '9'
+			isWord := isLetter || isDigit || c == '_'
+			isSpace := c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\v' || c == '\f'
 
-				if !isWord && !isSpace {
-					continue
-				}
-
-				if isSpace {
-					if !lastWasSpace && b.Len() > 0 {
-						b.WriteByte(' ')
-						lastWasSpace = true
-					}
-					continue
-				}
-
-				if c >= 'A' && c <= 'Z' {
-					b.WriteByte(c + 32)
-				} else {
-					b.WriteByte(c)
-				}
-				lastWasSpace = false
-			} else {
-				r, size := utf8.DecodeRuneInString(s[i:])
-				i += size
-				isWord := unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_'
-				isSpace := unicode.IsSpace(r)
-
-				if !isWord && !isSpace {
-					continue
-				}
-
-				if isSpace {
-					if !lastWasSpace && b.Len() > 0 {
-						b.WriteByte(' ')
-						lastWasSpace = true
-					}
-					continue
-				}
-
-				b.WriteRune(unicode.ToLower(r))
-				lastWasSpace = false
+			if !isWord && !isSpace {
+				continue
 			}
-		}
 
-		res := b.String()
-		if len(res) > 0 && res[len(res)-1] == ' ' {
-			return res[:len(res)-1]
+			if isSpace {
+				if !lastWasSpace && b.Len() > 0 {
+					b.WriteByte(' ')
+					lastWasSpace = true
+				}
+				continue
+			}
+
+			if c >= 'A' && c <= 'Z' {
+				b.WriteByte(c + 32)
+			} else {
+				b.WriteByte(c)
+			}
+			lastWasSpace = false
+		} else {
+			r, size := utf8.DecodeRuneInString(s[i:])
+			i += size
+			isWord := unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_'
+			isSpace := unicode.IsSpace(r)
+
+			if !isWord && !isSpace {
+				continue
+			}
+
+			if isSpace {
+				if !lastWasSpace && b.Len() > 0 {
+					b.WriteByte(' ')
+					lastWasSpace = true
+				}
+				continue
+			}
+
+			b.WriteRune(unicode.ToLower(r))
+			lastWasSpace = false
 		}
-		return res
 	}
 
+	res := b.String()
+	if len(res) > 0 && res[len(res)-1] == ' ' {
+		return res[:len(res)-1]
+	}
+	return res
+}
+
+// NormalizeAndCompare normalizes both strings and compares them
+func NormalizeAndCompare(str1, str2 string) bool {
 	// Normalize both strings
 	normalizedStr1 := normalizeString(str1)
 	normalizedStr2 := normalizeString(str2)
 
 	// Compare the normalized strings
 	return normalizedStr1 == normalizedStr2
+}
+
+// NormalizeAndComparePlural normalizes both strings and compares them, allowing simple plural forms ("s", "es").
+func NormalizeAndComparePlural(str1, str2 string) bool {
+	normalizedStr1 := normalizeString(str1)
+	normalizedStr2 := normalizeString(str2)
+
+	if normalizedStr1 == normalizedStr2 {
+		return true
+	}
+
+	// Ensure normalizedStr1 is the shorter one for simplicity
+	if len(normalizedStr1) > len(normalizedStr2) {
+		normalizedStr1, normalizedStr2 = normalizedStr2, normalizedStr1
+	}
+
+	// Check if s2 is s1 + "s"
+	if len(normalizedStr2) == len(normalizedStr1)+1 && strings.HasSuffix(normalizedStr2, "s") && normalizedStr2[:len(normalizedStr1)] == normalizedStr1 {
+		return true
+	}
+
+	// Check if s2 is s1 + "es"
+	if len(normalizedStr2) == len(normalizedStr1)+2 && strings.HasSuffix(normalizedStr2, "es") && normalizedStr2[:len(normalizedStr1)] == normalizedStr1 {
+		return true
+	}
+
+	return false
 }

--- a/service/StringUtilsService_test.go
+++ b/service/StringUtilsService_test.go
@@ -26,3 +26,32 @@ func TestNormalizeAndCompare(t *testing.T) {
 		}
 	}
 }
+
+func TestNormalizeAndComparePlural(t *testing.T) {
+	tests := []struct {
+		s1   string
+		s2   string
+		want bool
+	}{
+		{"apple", "apples", true},
+		{"apples", "apple", true},
+		{"box", "boxes", true},
+		{"boxes", "box", true},
+		{"city", "cities", false}, // We don't handle complex plurals right now per simple spec
+		{"apple", "orange", false},
+		{"car", "cars", true},
+		{"cars", "car", true},
+		{"dog", "doges", true}, // "dog" + "es" = "doges", but wait: doges vs dog, len=5 vs 3, diff=2. "es" matches. Wait, is "doges" a plural of "dog"? No, "dogs" is. But simple rule allows it. That's fine per spec.
+		{"match", "matches", true},
+		{"matches", "match", true},
+		{"apple", "apple", true},
+		{"", "", true},
+		{"a", "as", true},
+	}
+
+	for _, tt := range tests {
+		if got := NormalizeAndComparePlural(tt.s1, tt.s2); got != tt.want {
+			t.Errorf("NormalizeAndComparePlural(%q, %q) = %v; want %v", tt.s1, tt.s2, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
This PR updates the category game to accept simple plural forms of words when guessing. 

Changes include:
- Refactored `NormalizeAndCompare` in `service/StringUtilsService.go` to extract `normalizeString`.
- Added `NormalizeAndComparePlural` to accept exact matches as well as simple plural variations (e.g., "apple" vs "apples", "box" vs "boxes").
- Added unit tests for the new plural matching logic in `service/StringUtilsService_test.go`.
- Updated all usages of guess validation in the category game inside `controller/bot.go` and `controller/categoryBot/categoryBot.go` to use the new plural-aware function.

---
*PR created automatically by Jules for task [6808635767090864906](https://jules.google.com/task/6808635767090864906) started by @MUSTAFA-A-KHAN*