### PR TITLE
Fix empty database name error on /daily command

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,7 @@ var App Config
 func Load(token string) {
 	App = Config{
 		CatTelegramToken: token,
+		DatabaseName:     "Telegram",
 	}
 
 	if App.CatTelegramToken == "" {


### PR DESCRIPTION
Fixes an issue where running `/daily` would throw a "database name cannot be empty" error because `config.App.DatabaseName` was not being set upon configuration loading.

---
*PR created automatically by Jules for task [2097673851070116437](https://jules.google.com/task/2097673851070116437) started by @MUSTAFA-A-KHAN*