### PR TITLE
feat: Add ScheduleBot for cron-based message scheduling

### DIFF
--- a/controller/schedulebot/db.go
+++ b/controller/schedulebot/db.go
@@ -1,0 +1,63 @@
+package schedulebot
+
+import (
+	"context"
+
+	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/config"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+type ScheduledMessage struct {
+	ID             primitive.ObjectID `bson:"_id,omitempty"`
+	ChatID         int64              `bson:"chat_id"`
+	AddedBy        int                `bson:"added_by"`
+	CronExpression string             `bson:"cron_expression"`
+
+	// Message components
+	Text      string `bson:"text,omitempty"`
+	Caption   string `bson:"caption,omitempty"`
+	FileID    string `bson:"file_id,omitempty"`
+	MediaType string `bson:"media_type,omitempty"` // photo, audio, document, video, animation, voice
+}
+
+func GetCollection(client *mongo.Client) *mongo.Collection {
+	return client.Database(config.App.DatabaseName).Collection("ScheduledMessages")
+}
+
+func saveSchedule(client *mongo.Client, msg ScheduledMessage) (*mongo.InsertOneResult, error) {
+	collection := GetCollection(client)
+	return collection.InsertOne(context.Background(), msg)
+}
+
+func deleteSchedule(client *mongo.Client, chatID int64, id primitive.ObjectID) (*mongo.DeleteResult, error) {
+	collection := GetCollection(client)
+	return collection.DeleteOne(context.Background(), bson.M{"_id": id, "chat_id": chatID})
+}
+
+func getSchedules(client *mongo.Client, chatID int64) ([]ScheduledMessage, error) {
+	collection := GetCollection(client)
+	cursor, err := collection.Find(context.Background(), bson.M{"chat_id": chatID})
+	if err != nil {
+		return nil, err
+	}
+	var schedules []ScheduledMessage
+	if err := cursor.All(context.Background(), &schedules); err != nil {
+		return nil, err
+	}
+	return schedules, nil
+}
+
+func getAllSchedules(client *mongo.Client) ([]ScheduledMessage, error) {
+	collection := GetCollection(client)
+	cursor, err := collection.Find(context.Background(), bson.M{})
+	if err != nil {
+		return nil, err
+	}
+	var schedules []ScheduledMessage
+	if err := cursor.All(context.Background(), &schedules); err != nil {
+		return nil, err
+	}
+	return schedules, nil
+}

--- a/controller/schedulebot/handlers.go
+++ b/controller/schedulebot/handlers.go
@@ -1,0 +1,317 @@
+package schedulebot
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-telegram-bot-api/telegram-bot-api"
+	"github.com/robfig/cron/v3"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+type AdminCacheEntry struct {
+	Admins    map[int]bool
+	ExpiresAt time.Time
+}
+
+var (
+	adminCache = make(map[int64]AdminCacheEntry)
+	adminMutex sync.RWMutex
+
+	// State for conversational additions: map[chatID]map[userID]cronString
+	addingState = make(map[int64]map[int]string)
+	stateMutex  sync.RWMutex
+
+	// Track which job ID maps to which MongoDB ID
+	cronJobs   = make(map[string]cron.EntryID)
+	cronJobsMu sync.RWMutex
+)
+
+// isAdmin checks if the user is an administrator in the group.
+func isAdmin(bot *tgbotapi.BotAPI, chatID int64, userID int) bool {
+	if chatID > 0 { // Private chat
+		return true
+	}
+
+	adminMutex.RLock()
+	entry, exists := adminCache[chatID]
+	adminMutex.RUnlock()
+
+	if exists && time.Now().Before(entry.ExpiresAt) {
+		return entry.Admins[userID]
+	}
+
+	admins, err := bot.GetChatAdministrators(tgbotapi.ChatConfig{ChatID: chatID})
+	if err != nil {
+		log.Printf("Failed to get chat administrators for chat %d: %v", chatID, err)
+		return false
+	}
+
+	newAdmins := make(map[int]bool)
+	for _, admin := range admins {
+		newAdmins[admin.User.ID] = true
+	}
+
+	adminMutex.Lock()
+	adminCache[chatID] = AdminCacheEntry{
+		Admins:    newAdmins,
+		ExpiresAt: time.Now().Add(5 * time.Minute),
+	}
+	adminMutex.Unlock()
+
+	return newAdmins[userID]
+}
+
+func sendMessage(bot *tgbotapi.BotAPI, chatID int64, text string) {
+	msg := tgbotapi.NewMessage(chatID, text)
+	msg.ParseMode = "Markdown"
+	bot.Send(msg)
+}
+
+func loadSchedulesFromDB(client *mongo.Client) {
+	schedules, err := getAllSchedules(client)
+	if err != nil {
+		log.Printf("Failed to load schedules: %v", err)
+		return
+	}
+
+	for _, s := range schedules {
+		scheduleJob(s)
+	}
+}
+
+func scheduleJob(s ScheduledMessage) {
+	idStr := s.ID.Hex()
+	entryID, err := cronParser.AddFunc(s.CronExpression, func() {
+		executeSchedule(s)
+	})
+	if err != nil {
+		log.Printf("Failed to schedule job %s: %v", idStr, err)
+		return
+	}
+
+	cronJobsMu.Lock()
+	cronJobs[idStr] = entryID
+	cronJobsMu.Unlock()
+}
+
+func executeSchedule(s ScheduledMessage) {
+	if botInstance == nil {
+		return
+	}
+
+	if s.MediaType == "" || s.MediaType == "text" {
+		msg := tgbotapi.NewMessage(s.ChatID, s.Text)
+		botInstance.Send(msg)
+		return
+	}
+
+	// Handle media
+	var sendMsg tgbotapi.Chattable
+	switch s.MediaType {
+	case "photo":
+		msg := tgbotapi.NewPhotoShare(s.ChatID, s.FileID)
+		msg.Caption = s.Caption
+		sendMsg = msg
+	case "video":
+		msg := tgbotapi.NewVideoShare(s.ChatID, s.FileID)
+		msg.Caption = s.Caption
+		sendMsg = msg
+	case "animation":
+		msg := tgbotapi.NewAnimationShare(s.ChatID, s.FileID)
+		msg.Caption = s.Caption
+		sendMsg = msg
+	case "audio":
+		msg := tgbotapi.NewAudioShare(s.ChatID, s.FileID)
+		msg.Caption = s.Caption
+		sendMsg = msg
+	case "document":
+		msg := tgbotapi.NewDocumentShare(s.ChatID, s.FileID)
+		msg.Caption = s.Caption
+		sendMsg = msg
+	case "voice":
+		msg := tgbotapi.NewVoiceShare(s.ChatID, s.FileID)
+		msg.Caption = s.Caption
+		sendMsg = msg
+	}
+
+	if sendMsg != nil {
+		botInstance.Send(sendMsg)
+	}
+}
+
+func handleMessage(bot *tgbotapi.BotAPI, message *tgbotapi.Message, client *mongo.Client) {
+	if message == nil {
+		return
+	}
+
+	chatID := message.Chat.ID
+	userID := message.From.ID
+
+	// Check if user is in adding state
+	stateMutex.RLock()
+	userState, chatHasState := addingState[chatID]
+	var pendingCron string
+	var hasPending bool
+	if chatHasState {
+		pendingCron, hasPending = userState[userID]
+	}
+	stateMutex.RUnlock()
+
+	if hasPending && !message.IsCommand() {
+		// They are sending the message to be scheduled
+		var mediaType, fileID, text, caption string
+
+		if message.Photo != nil && len(*message.Photo) > 0 {
+			mediaType = "photo"
+			photos := *message.Photo
+			fileID = photos[len(photos)-1].FileID
+			caption = message.Caption
+		} else if message.Video != nil {
+			mediaType = "video"
+			fileID = message.Video.FileID
+			caption = message.Caption
+		} else if message.Animation != nil {
+			mediaType = "animation"
+			fileID = message.Animation.FileID
+			caption = message.Caption
+		} else if message.Audio != nil {
+			mediaType = "audio"
+			fileID = message.Audio.FileID
+			caption = message.Caption
+		} else if message.Document != nil {
+			mediaType = "document"
+			fileID = message.Document.FileID
+			caption = message.Caption
+		} else if message.Voice != nil {
+			mediaType = "voice"
+			fileID = message.Voice.FileID
+			caption = message.Caption
+		} else {
+			mediaType = "text"
+			text = message.Text
+		}
+
+		s := ScheduledMessage{
+			ID:             primitive.NewObjectID(),
+			ChatID:         chatID,
+			AddedBy:        userID,
+			CronExpression: pendingCron,
+			MediaType:      mediaType,
+			FileID:         fileID,
+			Text:           text,
+			Caption:        caption,
+		}
+
+		_, err := saveSchedule(client, s)
+		if err != nil {
+			sendMessage(bot, chatID, "❌ Failed to save scheduled message.")
+		} else {
+			scheduleJob(s)
+			sendMessage(bot, chatID, "✅ Message scheduled successfully.")
+		}
+
+		// Clear state
+		stateMutex.Lock()
+		delete(addingState[chatID], userID)
+		stateMutex.Unlock()
+		return
+	}
+
+	if !message.IsCommand() {
+		return
+	}
+
+	command := message.Command()
+
+	// Only admins can manage schedules
+	if command == "schedule" || command == "listschedules" || command == "cancelschedule" {
+		if !isAdmin(bot, chatID, userID) {
+			sendMessage(bot, chatID, "❌ You must be an admin to use this command.")
+			return
+		}
+	}
+
+	switch command {
+	case "schedule":
+		args := strings.TrimSpace(message.CommandArguments())
+		if args == "" {
+			sendMessage(bot, chatID, "Usage: `/schedule <cron_expression>`\nExample: `/schedule 0 10 * * *` (Every day at 10 AM)\n\nYou can also use format: `* * * * *` (minute, hour, day of month, month, day of week).")
+			return
+		}
+
+		// Validate cron expression
+		_, err := cron.ParseStandard(args)
+		if err != nil {
+			sendMessage(bot, chatID, "❌ Invalid cron expression. Please use standard cron format (e.g. `0 10 * * *`).")
+			return
+		}
+
+		// Save state
+		stateMutex.Lock()
+		if addingState[chatID] == nil {
+			addingState[chatID] = make(map[int]string)
+		}
+		addingState[chatID][userID] = args
+		stateMutex.Unlock()
+
+		msg := tgbotapi.NewMessage(chatID, "Cron expression accepted! Now send the message (text, photo, document, etc.) you want to schedule.")
+		msg.ReplyMarkup = tgbotapi.ForceReply{ForceReply: true, Selective: true}
+		bot.Send(msg)
+
+	case "listschedules":
+		schedules, err := getSchedules(client, chatID)
+		if err != nil {
+			sendMessage(bot, chatID, "❌ Failed to fetch schedules.")
+			return
+		}
+
+		if len(schedules) == 0 {
+			sendMessage(bot, chatID, "No active scheduled messages in this chat.")
+			return
+		}
+
+		var sb strings.Builder
+		sb.WriteString("📅 *Scheduled Messages:*\n\n")
+		for i, s := range schedules {
+			sb.WriteString(fmt.Sprintf("%d. ID: `%s`\n   Cron: `%s`\n   Type: %s\n\n", i+1, s.ID.Hex(), s.CronExpression, s.MediaType))
+		}
+		sb.WriteString("Use `/cancelschedule <id>` to remove one.")
+		sendMessage(bot, chatID, sb.String())
+
+	case "cancelschedule":
+		args := strings.TrimSpace(message.CommandArguments())
+		if args == "" {
+			sendMessage(bot, chatID, "Usage: `/cancelschedule <id>`")
+			return
+		}
+
+		objID, err := primitive.ObjectIDFromHex(args)
+		if err != nil {
+			sendMessage(bot, chatID, "❌ Invalid schedule ID format.")
+			return
+		}
+
+		res, err := deleteSchedule(client, chatID, objID)
+		if err != nil {
+			sendMessage(bot, chatID, "❌ Failed to delete schedule.")
+			return
+		}
+
+		if res.DeletedCount > 0 {
+			cronJobsMu.Lock()
+			if entryID, exists := cronJobs[args]; exists {
+				cronParser.Remove(entryID)
+				delete(cronJobs, args)
+			}
+			cronJobsMu.Unlock()
+			sendMessage(bot, chatID, "✅ Schedule deleted successfully.")
+		} else {
+			sendMessage(bot, chatID, "❌ Schedule not found.")
+		}
+	}
+}

--- a/controller/schedulebot/schedulebot.go
+++ b/controller/schedulebot/schedulebot.go
@@ -1,0 +1,55 @@
+package schedulebot
+
+import (
+	"log"
+
+	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/repository"
+	"github.com/go-telegram-bot-api/telegram-bot-api"
+	"github.com/robfig/cron/v3"
+)
+
+var (
+	botInstance *tgbotapi.BotAPI
+	cronParser  *cron.Cron
+)
+
+// StartScheduleBot initializes and starts the schedule bot
+func StartScheduleBot(token string) error {
+	bot, err := tgbotapi.NewBotAPI(token)
+	if err != nil {
+		return err
+	}
+
+	botInstance = bot
+	bot.Debug = true
+	log.Printf("ScheduleBot authorized on account %s", bot.Self.UserName)
+
+	client := repository.DbManager()
+	if client == nil {
+		log.Fatal("Failed to connect to MongoDB for ScheduleBot")
+	}
+
+	// Initialize cron with timezone support, seconds optional but standard cron parsing.
+	// standard parser is used to support "0 10 * * *"
+	cronParser = cron.New()
+	cronParser.Start()
+
+	// Load existing schedules from database and attach to cron
+	loadSchedulesFromDB(client)
+
+	u := tgbotapi.NewUpdate(0)
+	u.Timeout = 60
+
+	updates, err := bot.GetUpdatesChan(u)
+	if err != nil {
+		return err
+	}
+
+	for update := range updates {
+		if update.Message != nil {
+			go handleMessage(bot, update.Message, client)
+		}
+	}
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/klauspost/compress v1.13.6 // indirect
 	github.com/montanaflynn/stats v0.7.1 // indirect
+	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/technoweenie/multipartstreamer v1.0.1 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
 	github.com/xdg-go/scram v1.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/montanaflynn/stats v0.7.1 h1:etflOAAHORrCC44V+aR6Ftzort912ZU+YLiSTuV8
 github.com/montanaflynn/stats v0.7.1/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/technoweenie/multipartstreamer v1.0.1 h1:XRztA5MXiR1TIRHxH2uNxXxaIkKQDeX7m2XsSOlQEnM=

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/fontbot"
 	instagrambot "github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/instagramBot"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/modbot"
+	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/schedulebot"
 	"github.com/MUSTAFA-A-KHAN/telegram-bot-anime/controller/translator"
 )
 
@@ -21,11 +22,13 @@ func main() {
 	instagram := "7995903003:AAEcvtxq1Swak9W_uuMwQ-Jv-YXKOp_i-pw"
 	fontbotToken := "YOUR_FONT_BOT_TOKEN_HERE" // Replace with your actual font bot token
 	modbotToken := os.Getenv("MOD_BOT_TOKEN")  // Token for the moderator bot
+	scheduleBotToken := os.Getenv("SCHEDULE_BOT_TOKEN")
+
 	// WaitGroup to wait for all goroutines to finish
 	var wg sync.WaitGroup
 
-	// Add six tasks to the WaitGroup
-	wg.Add(6)
+	// Add seven tasks to the WaitGroup
+	wg.Add(7)
 
 	// Start bots in separate goroutines
 	go runWordBot(charades, &wg)
@@ -34,6 +37,7 @@ func main() {
 	go runTranslatorBot(&wg)
 	go runFontBot(fontbotToken, &wg)
 	go runModBot(modbotToken, &wg)
+	go runScheduleBot(scheduleBotToken, &wg)
 
 	// Wait for goroutines to complete
 	wg.Wait()
@@ -109,5 +113,20 @@ func runModBot(botToken string, wg *sync.WaitGroup) {
 	err := modbot.StartModBot(botToken)
 	if err != nil {
 		log.Printf("Error starting mod bot with token %s: %v\n", botToken, err)
+	}
+}
+
+// Function to start the schedule bot with error handling
+func runScheduleBot(botToken string, wg *sync.WaitGroup) {
+	defer wg.Done() // Decrement the wait group counter when this goroutine completes
+
+	if botToken == "" {
+		log.Println("SCHEDULE_BOT_TOKEN is empty. Skipping ScheduleBot startup.")
+		return
+	}
+
+	err := schedulebot.StartScheduleBot(botToken)
+	if err != nil {
+		log.Printf("Error starting schedule bot with token %s: %v\n", botToken, err)
 	}
 }


### PR DESCRIPTION
This PR introduces the new ScheduleBot module to the application architecture, resolving the user request to have a feature similar to ModBot but specifically for sending scheduled, cron-based responses.

**Key Additions:**
*   **`controller/schedulebot` Package**: Dedicated controllers for DB persistence (`db.go`), message routing and command parsing (`handlers.go`), and bot initialization (`schedulebot.go`).
*   **Cron Integration**: Implemented `github.com/robfig/cron/v3` for reliable robust cron execution (`* * * * *` standard parsing).
*   **Media Parsing Engine**: Supports all standard Telegram media formats (text, photo, audio, voice, video, document) for scheduling.
*   **MongoDB Schema `ScheduledMessages`**: Maps cron jobs to `primitive.ObjectID` locally and persists payloads robustly.
*   **Thread Safety**: Mutex-guarded state for multi-tenant interactions, protecting memory caches for admin permissions and interactive flows.
*   **`main.go` Binding**: Exposed `SCHEDULE_BOT_TOKEN` and updated the primary application lifecycle runner to `wg.Add(7)`.

---
*PR created automatically by Jules for task [16293156831290921944](https://jules.google.com/task/16293156831290921944) started by @MUSTAFA-A-KHAN*